### PR TITLE
Feature: Add Tests for Scrape Action

### DIFF
--- a/tests/Feature/Actions/Scrape/FetchHtmlTest.php
+++ b/tests/Feature/Actions/Scrape/FetchHtmlTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Scrape;
+
+use App\Actions\Scrape\FetchHtml;
+use App\Enums\Encoding;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Symfony\Component\DomCrawler\Crawler;
+use Tests\Feature\TestCase;
+
+final class FetchHtmlTest extends TestCase
+{
+    public function test_invokes_http_and_returns_crawler(): void
+    {
+        $url = 'https://example.com/test';
+        $htmlContent = '<html><body><h1>Test Content</h1><script>alert(1);</script></body></html>';
+
+        Http::fake([
+            $url => Http::response($htmlContent, 200),
+        ]);
+
+        $action = new FetchHtml(
+            retryTimes: 1,
+            sleepMilliseconds: 10,
+            useCache: false
+        );
+
+        $crawler = $action($url, Encoding::UTF_8);
+
+        $this->assertInstanceOf(Crawler::class, $crawler);
+        $this->assertStringContainsString('Test Content', $crawler->html());
+
+        Http::assertSentCount(1);
+    }
+
+    public function test_uses_cache_when_enabled(): void
+    {
+        $url = 'https://example.com/cached';
+        $cachedHtml = '<html><body>Cached Content</body></html>';
+
+        Cache::put('url:'.$url, $cachedHtml);
+
+        Http::fake();
+
+        $action = new FetchHtml(
+            retryTimes: 1,
+            sleepMilliseconds: 10,
+            useCache: true
+        );
+
+        $crawler = $action($url, Encoding::UTF_8);
+
+        $this->assertInstanceOf(Crawler::class, $crawler);
+        $this->assertStringContainsString('Cached Content', $crawler->html());
+
+        Http::assertNothingSent();
+    }
+
+    public function test_converts_encoding(): void
+    {
+        $url = 'https://example.com/euc-jp';
+        // HTML content encoded in EUC-JP
+        $eucJpHtml = mb_convert_encoding('<html><body>日本語</body></html>', 'EUC-JP', 'UTF-8');
+
+        Http::fake([
+            $url => Http::response($eucJpHtml, 200),
+        ]);
+
+        $action = new FetchHtml(
+            retryTimes: 1,
+            sleepMilliseconds: 10,
+            useCache: false
+        );
+
+        $crawler = $action($url, Encoding::EUC_JP);
+
+        $this->assertInstanceOf(Crawler::class, $crawler);
+        // After conversion, it should be readable as UTF-8
+        $this->assertStringContainsString('日本語', $crawler->html());
+    }
+}

--- a/tests/Feature/Actions/Scrape/FetchHtmlTest.php
+++ b/tests/Feature/Actions/Scrape/FetchHtmlTest.php
@@ -22,13 +22,13 @@ final class FetchHtmlTest extends TestCase
             $url => Http::response($htmlContent, 200),
         ]);
 
-        $action = new FetchHtml(
+        $fetchHtml = new FetchHtml(
             retryTimes: 1,
             sleepMilliseconds: 10,
             useCache: false
         );
 
-        $crawler = $action($url, Encoding::UTF_8);
+        $crawler = $fetchHtml($url, Encoding::UTF_8);
 
         $this->assertInstanceOf(Crawler::class, $crawler);
         $this->assertStringContainsString('Test Content', $crawler->html());
@@ -45,13 +45,13 @@ final class FetchHtmlTest extends TestCase
 
         Http::fake();
 
-        $action = new FetchHtml(
+        $fetchHtml = new FetchHtml(
             retryTimes: 1,
             sleepMilliseconds: 10,
             useCache: true
         );
 
-        $crawler = $action($url, Encoding::UTF_8);
+        $crawler = $fetchHtml($url, Encoding::UTF_8);
 
         $this->assertInstanceOf(Crawler::class, $crawler);
         $this->assertStringContainsString('Cached Content', $crawler->html());
@@ -69,13 +69,13 @@ final class FetchHtmlTest extends TestCase
             $url => Http::response($eucJpHtml, 200),
         ]);
 
-        $action = new FetchHtml(
+        $fetchHtml = new FetchHtml(
             retryTimes: 1,
             sleepMilliseconds: 10,
             useCache: false
         );
 
-        $crawler = $action($url, Encoding::EUC_JP);
+        $crawler = $fetchHtml($url, Encoding::EUC_JP);
 
         $this->assertInstanceOf(Crawler::class, $crawler);
         // After conversion, it should be readable as UTF-8

--- a/tests/Feature/Actions/Scrape/ScrapeActionTest.php
+++ b/tests/Feature/Actions/Scrape/ScrapeActionTest.php
@@ -25,7 +25,7 @@ final class ScrapeActionTest extends TestCase
         ]);
 
         // Mock PortalHandler to avoid database queries in CI where the portal connection is unmigrated
-        $this->app->bind(Handler::class, fn () => new class implements HandlerInterface
+        $this->app->bind(Handler::class, fn (): HandlerInterface => new class implements HandlerInterface
         {
             public function __invoke(LoggerInterface $logger): void {}
         });

--- a/tests/Feature/Actions/Scrape/ScrapeActionTest.php
+++ b/tests/Feature/Actions/Scrape/ScrapeActionTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Actions\Scrape;
 
+use App\Actions\Scrape\HandlerInterface;
+use App\Actions\Scrape\Portal\Handler;
 use App\Actions\Scrape\ScrapeAction;
 use App\Enums\SiteName;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Tests\Feature\TestCase;
 
@@ -20,6 +23,14 @@ final class ScrapeActionTest extends TestCase
         Http::fake([
             '*' => Http::response('<html><body></body></html>', 200),
         ]);
+
+        // Mock PortalHandler to avoid database queries in CI where the portal connection is unmigrated
+        $this->app->bind(Handler::class, function () {
+            return new class implements HandlerInterface
+            {
+                public function __invoke(LoggerInterface $logger): void {}
+            };
+        });
 
         $scrapeAction = app(ScrapeAction::class);
         $scrapeAction(null, new NullLogger);

--- a/tests/Feature/Actions/Scrape/ScrapeActionTest.php
+++ b/tests/Feature/Actions/Scrape/ScrapeActionTest.php
@@ -25,9 +25,9 @@ final class ScrapeActionTest extends TestCase
         $scrapeAction(null, new NullLogger);
 
         // Verify JapanHandler was invoked by checking its specific HTTP request
-        Http::assertSent(fn ($request): bool => $request->url() === 'https://japanese.simutrans.com?cmd=list');
+        Http::assertSent(fn ($request): bool => str_contains($request->url(), 'japanese.simutrans.com'));
         // Verify TwitransHandler was invoked
-        Http::assertSent(fn ($request): bool => $request->url() === 'https://wikiwiki.jp/twitrans?cmd=list');
+        Http::assertSent(fn ($request): bool => str_contains($request->url(), 'wikiwiki.jp/twitrans'));
     }
 
     public function test_invokes_specific_handler_when_site_provided(): void
@@ -39,7 +39,7 @@ final class ScrapeActionTest extends TestCase
         $scrapeAction = app(ScrapeAction::class);
         $scrapeAction(SiteName::Japan, new NullLogger);
 
-        Http::assertSent(fn ($request): bool => $request->url() === 'https://japanese.simutrans.com?cmd=list');
-        Http::assertNotSent(fn ($request): bool => $request->url() === 'https://wikiwiki.jp/twitrans?cmd=list');
+        Http::assertSent(fn ($request): bool => str_contains($request->url(), 'japanese.simutrans.com'));
+        Http::assertNotSent(fn ($request): bool => str_contains($request->url(), 'wikiwiki.jp/twitrans'));
     }
 }

--- a/tests/Feature/Actions/Scrape/ScrapeActionTest.php
+++ b/tests/Feature/Actions/Scrape/ScrapeActionTest.php
@@ -6,12 +6,15 @@ namespace Tests\Feature\Actions\Scrape;
 
 use App\Actions\Scrape\ScrapeAction;
 use App\Enums\SiteName;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Psr\Log\NullLogger;
 use Tests\Feature\TestCase;
 
 final class ScrapeActionTest extends TestCase
 {
+    use RefreshDatabase;
+
     public function test_invokes_handlers_for_all_sites_when_null_provided(): void
     {
         Http::fake([
@@ -19,10 +22,12 @@ final class ScrapeActionTest extends TestCase
         ]);
 
         $action = app(ScrapeAction::class);
-        $action(null, new NullLogger);
+        $action(null, new NullLogger());
 
-        // Just ensure no exceptions were thrown
-        $this->assertTrue(true);
+        // Verify JapanHandler was invoked by checking its specific HTTP request
+        Http::assertSent(fn ($request) => $request->url() === 'https://japanese.simutrans.com?cmd=list');
+        // Verify TwitransHandler was invoked
+        Http::assertSent(fn ($request) => $request->url() === 'https://wikiwiki.jp/twitrans?cmd=list');
     }
 
     public function test_invokes_specific_handler_when_site_provided(): void
@@ -32,8 +37,9 @@ final class ScrapeActionTest extends TestCase
         ]);
 
         $action = app(ScrapeAction::class);
-        $action(SiteName::Japan, new NullLogger);
+        $action(SiteName::Japan, new NullLogger());
 
-        $this->assertTrue(true);
+        Http::assertSent(fn ($request) => $request->url() === 'https://japanese.simutrans.com?cmd=list');
+        Http::assertNotSent(fn ($request) => $request->url() === 'https://wikiwiki.jp/twitrans?cmd=list');
     }
 }

--- a/tests/Feature/Actions/Scrape/ScrapeActionTest.php
+++ b/tests/Feature/Actions/Scrape/ScrapeActionTest.php
@@ -25,9 +25,9 @@ final class ScrapeActionTest extends TestCase
         $scrapeAction(null, new NullLogger);
 
         // Verify JapanHandler was invoked by checking its specific HTTP request
-        Http::assertSent(fn ($request): bool => str_contains($request->url(), 'japanese.simutrans.com'));
+        Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'japanese.simutrans.com'));
         // Verify TwitransHandler was invoked
-        Http::assertSent(fn ($request): bool => str_contains($request->url(), 'wikiwiki.jp/twitrans'));
+        Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'wikiwiki.jp/twitrans'));
     }
 
     public function test_invokes_specific_handler_when_site_provided(): void
@@ -39,7 +39,7 @@ final class ScrapeActionTest extends TestCase
         $scrapeAction = app(ScrapeAction::class);
         $scrapeAction(SiteName::Japan, new NullLogger);
 
-        Http::assertSent(fn ($request): bool => str_contains($request->url(), 'japanese.simutrans.com'));
-        Http::assertNotSent(fn ($request): bool => str_contains($request->url(), 'wikiwiki.jp/twitrans'));
+        Http::assertSent(fn ($request): bool => str_contains((string) $request->url(), 'japanese.simutrans.com'));
+        Http::assertNotSent(fn ($request): bool => str_contains((string) $request->url(), 'wikiwiki.jp/twitrans'));
     }
 }

--- a/tests/Feature/Actions/Scrape/ScrapeActionTest.php
+++ b/tests/Feature/Actions/Scrape/ScrapeActionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Scrape;
+
+use App\Actions\Scrape\ScrapeAction;
+use App\Enums\SiteName;
+use Illuminate\Support\Facades\Http;
+use Psr\Log\NullLogger;
+use Tests\Feature\TestCase;
+
+final class ScrapeActionTest extends TestCase
+{
+    public function test_invokes_handlers_for_all_sites_when_null_provided(): void
+    {
+        Http::fake([
+            '*' => Http::response('<html><body></body></html>', 200),
+        ]);
+
+        $action = app(ScrapeAction::class);
+        $action(null, new NullLogger);
+
+        // Just ensure no exceptions were thrown
+        $this->assertTrue(true);
+    }
+
+    public function test_invokes_specific_handler_when_site_provided(): void
+    {
+        Http::fake([
+            '*' => Http::response('<html><body></body></html>', 200),
+        ]);
+
+        $action = app(ScrapeAction::class);
+        $action(SiteName::Japan, new NullLogger);
+
+        $this->assertTrue(true);
+    }
+}

--- a/tests/Feature/Actions/Scrape/ScrapeActionTest.php
+++ b/tests/Feature/Actions/Scrape/ScrapeActionTest.php
@@ -25,11 +25,9 @@ final class ScrapeActionTest extends TestCase
         ]);
 
         // Mock PortalHandler to avoid database queries in CI where the portal connection is unmigrated
-        $this->app->bind(Handler::class, function () {
-            return new class implements HandlerInterface
-            {
-                public function __invoke(LoggerInterface $logger): void {}
-            };
+        $this->app->bind(Handler::class, fn () => new class implements HandlerInterface
+        {
+            public function __invoke(LoggerInterface $logger): void {}
         });
 
         $scrapeAction = app(ScrapeAction::class);

--- a/tests/Feature/Actions/Scrape/ScrapeActionTest.php
+++ b/tests/Feature/Actions/Scrape/ScrapeActionTest.php
@@ -18,8 +18,8 @@ final class ScrapeActionTest extends TestCase
             '*' => Http::response('<html><body></body></html>', 200),
         ]);
 
-        $action = app(ScrapeAction::class);
-        $action(null, new NullLogger);
+        $scrapeAction = app(ScrapeAction::class);
+        $scrapeAction(null, new NullLogger);
 
         // Just ensure no exceptions were thrown
         $this->assertTrue(true);
@@ -31,8 +31,8 @@ final class ScrapeActionTest extends TestCase
             '*' => Http::response('<html><body></body></html>', 200),
         ]);
 
-        $action = app(ScrapeAction::class);
-        $action(SiteName::Japan, new NullLogger);
+        $scrapeAction = app(ScrapeAction::class);
+        $scrapeAction(SiteName::Japan, new NullLogger);
 
         $this->assertTrue(true);
     }

--- a/tests/Feature/Actions/Scrape/ScrapeActionTest.php
+++ b/tests/Feature/Actions/Scrape/ScrapeActionTest.php
@@ -21,13 +21,13 @@ final class ScrapeActionTest extends TestCase
             '*' => Http::response('<html><body></body></html>', 200),
         ]);
 
-        $action = app(ScrapeAction::class);
-        $action(null, new NullLogger);
+        $scrapeAction = app(ScrapeAction::class);
+        $scrapeAction(null, new NullLogger);
 
         // Verify JapanHandler was invoked by checking its specific HTTP request
-        Http::assertSent(fn ($request) => $request->url() === 'https://japanese.simutrans.com?cmd=list');
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://japanese.simutrans.com?cmd=list');
         // Verify TwitransHandler was invoked
-        Http::assertSent(fn ($request) => $request->url() === 'https://wikiwiki.jp/twitrans?cmd=list');
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://wikiwiki.jp/twitrans?cmd=list');
     }
 
     public function test_invokes_specific_handler_when_site_provided(): void
@@ -36,10 +36,10 @@ final class ScrapeActionTest extends TestCase
             '*' => Http::response('<html><body></body></html>', 200),
         ]);
 
-        $action = app(ScrapeAction::class);
-        $action(SiteName::Japan, new NullLogger);
+        $scrapeAction = app(ScrapeAction::class);
+        $scrapeAction(SiteName::Japan, new NullLogger);
 
-        Http::assertSent(fn ($request) => $request->url() === 'https://japanese.simutrans.com?cmd=list');
-        Http::assertNotSent(fn ($request) => $request->url() === 'https://wikiwiki.jp/twitrans?cmd=list');
+        Http::assertSent(fn ($request): bool => $request->url() === 'https://japanese.simutrans.com?cmd=list');
+        Http::assertNotSent(fn ($request): bool => $request->url() === 'https://wikiwiki.jp/twitrans?cmd=list');
     }
 }


### PR DESCRIPTION
This PR adds tests for the Scrape actions in SimutransCrossSearch.

Changes:
- Added `tests/Feature/Actions/Scrape/FetchHtmlTest.php` to verify HTTP fetching and caching logic.
- Added `tests/Feature/Actions/Scrape/ScrapeActionTest.php` to verify that all handlers are invoked correctly.