### PR TITLE
chore: update packages, GHA versions, add Dependabot

### DIFF
--- a/.github/actions/php/action.yml
+++ b/.github/actions/php/action.yml
@@ -9,4 +9,4 @@ runs:
         php-version: "8.3"
         coverage: none
 
-    - uses: "ramsey/composer-install@v3"
+    - uses: "ramsey/composer-install@v4"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Composer is handled by auto-package-update.yml (weekly, Sunday)
+  # Dependabot covers GitHub Actions only to avoid duplicate PRs
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "00:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5

--- a/.github/workflows/auto-package-update.yml
+++ b/.github/workflows/auto-package-update.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
           # Must be used to trigger workflow after push
@@ -25,7 +25,7 @@ jobs:
         run: composer update && composer bump && composer update
 
       - # commit only to core contributors who have repository access
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "[ci] package-updates"
           commit_author: "GitHub Action <actions@github.com>"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: .env
         run: php -r "copy('.env.ci', '.env');"
@@ -30,7 +30,7 @@ jobs:
         test_suite: [Unit, Feature]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: .env
         run: php -r "copy('.env.ci', '.env');"
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload Laravel Logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: TestLaravelLog-${{ matrix.test_suite }}
           path: storage/logs
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install SSH key
         run: >

--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == '128na/SimutransCrossSearch'
     steps:
       - if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Must be used to trigger workflow after push
           token: ${{ secrets.ACCESS_TOKEN }}
@@ -23,7 +23,7 @@ jobs:
       - run: vendor/bin/pint
 
       - # commit only to core contributors who have repository access
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "[rector] Rector fixes"
           commit_author: "GitHub Action <actions@github.com>"

--- a/composer.lock
+++ b/composer.lock
@@ -2023,16 +2023,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v4.3.0",
+            "version": "v4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "19ebb1ee4d057debceccf70ff01950e6a6114edc"
+                "reference": "6a9dd03f45a4b200abfd0ff644745b23fa7baaaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/19ebb1ee4d057debceccf70ff01950e6a6114edc",
-                "reference": "19ebb1ee4d057debceccf70ff01950e6a6114edc",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/6a9dd03f45a4b200abfd0ff644745b23fa7baaaa",
+                "reference": "6a9dd03f45a4b200abfd0ff644745b23fa7baaaa",
                 "shasum": ""
             },
             "require": {
@@ -2087,7 +2087,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v4.3.0"
+                "source": "https://github.com/livewire/livewire/tree/v4.3.1"
             },
             "funding": [
                 {
@@ -2095,7 +2095,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-01T00:46:07+00:00"
+            "time": "2026-06-02T08:58:52+00:00"
         },
         {
             "name": "mariosimao/notion-sdk-php",


### PR DESCRIPTION
## Summary

- composer patch/minor パッケージを一括更新
- GitHub Actions を最新メジャーバージョンに更新
- Dependabot を追加 (GitHub Actions のみ、毎週日曜)

## パッケージ更新

| Package | Before | After |
|---|---|---|
| laravel/framework | 12.56.0 | 12.61.0 |
| livewire/livewire | 4.2.4 | 4.3.1 |
| phpunit/phpunit | 12.5.17 | 12.5.28 |
| rector/rector | 2.4.1 | 2.4.5 |
| larastan/larastan | 3.9.3 | 3.10.0 |
| symfony/* | 7.4.8 | 7.4.13 |

## GitHub Actions 更新

| Action | Before | After |
|---|---|---|
| actions/checkout | @v4 | @v6 |
| actions/upload-artifact | @v4 | @v7 |
| stefanzweifel/git-auto-commit-action | @v5 | @v7 |
| ramsey/composer-install | @v3 | @v4 |

## Dependabot

- GitHub Actions のみ追跡 (composer は `auto-package-update.yml` で対応済みのため重複回避)

## スキップしたメジャー更新

- **laravel/framework 12→13**: breaking changes 要調査

## Test plan

- [ ] CI (phpstan + phpunit) が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)