### PR TITLE
Add known-risks ledger and fix Assurance Audit findings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 APP_NAME=Simutransアドオン横断検索
 APP_ENV=local
 APP_KEY=
-APP_DEBUG=true
+APP_DEBUG=false
 APP_URL=http://localhost
 
 LOG_CHANNEL=stack

--- a/app/Actions/Extract/Japan/Handler.php
+++ b/app/Actions/Extract/Japan/Handler.php
@@ -6,6 +6,7 @@ namespace App\Actions\Extract\Japan;
 
 use App\Actions\Extract\ChunkRawPages;
 use App\Actions\Extract\HandlerInterface;
+use App\Actions\Extract\MarkExtractFailed;
 use App\Actions\Extract\SyncPak;
 use App\Actions\Extract\UpdateOrCreatePage;
 use App\Enums\SiteName;
@@ -23,6 +24,7 @@ final readonly class Handler implements HandlerInterface
         private ExtractContents $extractContents,
         private UpdateOrCreatePage $updateOrCreatePage,
         private SyncPak $syncPak,
+        private MarkExtractFailed $markExtractFailed,
     ) {}
 
     #[\Override]
@@ -49,9 +51,10 @@ final readonly class Handler implements HandlerInterface
 
                         ($this->syncPak)($page, $contents['paks']);
                     }
+
+                    $this->markExtractFailed->clear($rawPage);
                 } catch (\Throwable $th) {
-                    $logger->error('failed', [$rawPage->url, $th]);
-                    $rawPage->delete();
+                    ($this->markExtractFailed)($logger, $rawPage, $th);
                 }
             }
         });

--- a/app/Actions/Extract/MarkExtractFailed.php
+++ b/app/Actions/Extract/MarkExtractFailed.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Extract;
+
+use App\Models\RawPage;
+use Carbon\CarbonImmutable;
+use Psr\Log\LoggerInterface;
+
+/**
+ * 抽出失敗時の共通処理。
+ *
+ * 以前は失敗時に RawPage を delete() していたが、一過性のエラーでも唯一の
+ * スクレイプ結果が恒久消失してしまうため、削除をやめて失敗を隔離・可視化する。
+ * 次回以降のリトライで成功すればフラグはクリアされ自己回復する。
+ */
+final class MarkExtractFailed
+{
+    public function __invoke(LoggerInterface $logger, RawPage $rawPage, \Throwable $throwable): void
+    {
+        $logger->error('failed', [$rawPage->url, $throwable]);
+        $rawPage->update(['extract_failed_at' => CarbonImmutable::now()]);
+    }
+
+    /**
+     * 抽出が成功したら過去の失敗フラグをクリアする（自己回復）。
+     */
+    public function clear(RawPage $rawPage): void
+    {
+        if ($rawPage->extract_failed_at !== null) {
+            $rawPage->update(['extract_failed_at' => null]);
+        }
+    }
+}

--- a/app/Actions/Extract/Portal/Handler.php
+++ b/app/Actions/Extract/Portal/Handler.php
@@ -6,6 +6,7 @@ namespace App\Actions\Extract\Portal;
 
 use App\Actions\Extract\ChunkRawPages;
 use App\Actions\Extract\HandlerInterface;
+use App\Actions\Extract\MarkExtractFailed;
 use App\Actions\Extract\SyncPak;
 use App\Actions\Extract\UpdateOrCreatePage;
 use App\Enums\SiteName;
@@ -23,6 +24,7 @@ final readonly class Handler implements HandlerInterface
         private ExtractContents $extractContents,
         private UpdateOrCreatePage $updateOrCreatePage,
         private SyncPak $syncPak,
+        private MarkExtractFailed $markExtractFailed,
     ) {}
 
     #[\Override]
@@ -51,9 +53,10 @@ final readonly class Handler implements HandlerInterface
 
                         ($this->syncPak)($page, $contents['paks']);
                     }
+
+                    $this->markExtractFailed->clear($rawPage);
                 } catch (\Throwable $th) {
-                    $logger->error('failed', [$rawPage->url, $th]);
-                    $rawPage->delete();
+                    ($this->markExtractFailed)($logger, $rawPage, $th);
                 }
             }
         });

--- a/app/Actions/Extract/Twitrans/Handler.php
+++ b/app/Actions/Extract/Twitrans/Handler.php
@@ -6,6 +6,7 @@ namespace App\Actions\Extract\Twitrans;
 
 use App\Actions\Extract\ChunkRawPages;
 use App\Actions\Extract\HandlerInterface;
+use App\Actions\Extract\MarkExtractFailed;
 use App\Actions\Extract\SyncPak;
 use App\Actions\Extract\UpdateOrCreatePage;
 use App\Enums\SiteName;
@@ -23,6 +24,7 @@ final readonly class Handler implements HandlerInterface
         private ExtractContents $extractContents,
         private UpdateOrCreatePage $updateOrCreatePage,
         private SyncPak $syncPak,
+        private MarkExtractFailed $markExtractFailed,
     ) {}
 
     #[\Override]
@@ -49,9 +51,10 @@ final readonly class Handler implements HandlerInterface
 
                         ($this->syncPak)($page, $contents['paks']);
                     }
+
+                    $this->markExtractFailed->clear($rawPage);
                 } catch (\Throwable $th) {
-                    $logger->error('failed', [$rawPage->url, $th]);
-                    $rawPage->delete();
+                    ($this->markExtractFailed)($logger, $rawPage, $th);
                 }
             }
         });

--- a/app/Actions/Logging/ConvertDiscord.php
+++ b/app/Actions/Logging/ConvertDiscord.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace App\Actions\Logging;
 
+use Illuminate\Contracts\Config\Repository;
 use MarvinLabs\DiscordLogger\Converters\SimpleRecordConverter;
 use MarvinLabs\DiscordLogger\Discord\Embed;
 use MarvinLabs\DiscordLogger\Discord\Message;
 
 final class ConvertDiscord extends SimpleRecordConverter
 {
+    public function __construct(Repository $config, private readonly SecretScrubber $secretScrubber)
+    {
+        parent::__construct($config);
+    }
+
     /**
      * @param  array{datetime:\DateTime,level_name:int,message:string,context:array<int|string,mixed>}  $record
      */
@@ -17,7 +23,15 @@ final class ConvertDiscord extends SimpleRecordConverter
     protected function addMessageContent(Message $message, array $record): void
     {
         try {
+            // Discord は外部サービスへ送出されるため、組み立て前に機密値を伏字化する。
+            $record['message'] = $this->secretScrubber->scrub($record['message']);
+            $record['context'] = $this->secretScrubber->scrubArray($record['context']);
+
             $stacktrace = $this->getStacktrace($record);
+            if ($stacktrace !== null) {
+                $stacktrace = $this->secretScrubber->scrub($stacktrace);
+            }
+
             if (! in_array($stacktrace, [null, '', '0'], true)) {
                 $this->makeErrorMessage($message, $record, $stacktrace);
             } else {

--- a/app/Actions/Logging/ConvertDiscord.php
+++ b/app/Actions/Logging/ConvertDiscord.php
@@ -23,11 +23,14 @@ final class ConvertDiscord extends SimpleRecordConverter
     protected function addMessageContent(Message $message, array $record): void
     {
         try {
+            // context['exception'] が Throwable のままの状態で先に取得する。
+            // scrubArray() は Throwable を文字列化してしまうため、先に呼ぶと取得できなくなる。
+            $stacktrace = $this->getStacktrace($record);
+
             // Discord は外部サービスへ送出されるため、組み立て前に機密値を伏字化する。
             $record['message'] = $this->secretScrubber->scrub($record['message']);
             $record['context'] = $this->secretScrubber->scrubArray($record['context']);
 
-            $stacktrace = $this->getStacktrace($record);
             if ($stacktrace !== null) {
                 $stacktrace = $this->secretScrubber->scrub($stacktrace);
             }
@@ -40,6 +43,19 @@ final class ConvertDiscord extends SimpleRecordConverter
         } catch (\Throwable $throwable) {
             report($throwable);
         }
+    }
+
+    /**
+     * 親クラスの addMessageStacktrace は未伏字化の生スタックトレースで
+     * $message->file を上書きしてしまうため、何もしないようにする
+     * （伏字化済みのスタックトレースは addMessageContent 内で既に添付済み）。
+     *
+     * @param  array{datetime:\DateTime,level_name:int,message:string,context:array<int|string,mixed>}  $record
+     */
+    #[\Override]
+    protected function addMessageStacktrace(Message $message, array $record): void
+    {
+        // no-op: see method docblock.
     }
 
     /**

--- a/app/Actions/Logging/SecretScrubber.php
+++ b/app/Actions/Logging/SecretScrubber.php
@@ -17,6 +17,11 @@ final class SecretScrubber
 {
     private const string MASK = '[REDACTED]';
 
+    /**
+     * @var list<string>|null
+     */
+    private ?array $cachedSecrets = null;
+
     public function scrub(string $value): string
     {
         $secrets = $this->secrets();
@@ -67,11 +72,17 @@ final class SecretScrubber
 
     /**
      * 伏字化対象の機密値一覧（短すぎる値・空値は誤爆防止のため対象から除外する）。
+     * リクエスト中に変わらない値なのでインスタンス単位でキャッシュする
+     * （静的キャッシュにすると PHPUnit のテスト間で Config 変更が反映されなくなるため避ける）。
      *
      * @return list<string>
      */
     private function secrets(): array
     {
+        if ($this->cachedSecrets !== null) {
+            return $this->cachedSecrets;
+        }
+
         $candidates = [
             Config::get('services.notion.secret'),
             Config::get('logging.channels.discord.url'),
@@ -79,7 +90,7 @@ final class SecretScrubber
             Config::get('database.connections.portal.password'),
         ];
 
-        return array_values(array_unique(array_filter(
+        return $this->cachedSecrets = array_values(array_unique(array_filter(
             $candidates,
             // 未設定(null)や開発環境の "root" 等の短い値まで伏字化すると
             // ログ本文を無関係な部分まで壊してしまうため、4文字未満は対象外にする。

--- a/app/Actions/Logging/SecretScrubber.php
+++ b/app/Actions/Logging/SecretScrubber.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Logging;
+
+use Illuminate\Support\Facades\Config;
+
+/**
+ * ログ・例外レポート・Discord 送出に機密値が混入するのを防ぐための伏字化。
+ *
+ * 例外メッセージやスタックトレース、Guzzle 例外に含まれる Authorization ヘッダ等に
+ * 紛れ込んだ既知の機密値（Notion シークレット、Discord Webhook URL、DB パスワード）を
+ * 送出直前に [REDACTED] へ置換する予防制御。
+ */
+final class SecretScrubber
+{
+    private const string MASK = '[REDACTED]';
+
+    public function scrub(string $value): string
+    {
+        $secrets = $this->secrets();
+        if ($secrets === []) {
+            return $value;
+        }
+
+        return str_replace($secrets, self::MASK, $value);
+    }
+
+    /**
+     * @param  array<array-key,mixed>  $context
+     * @return array<array-key,mixed>
+     */
+    public function scrubArray(array $context): array
+    {
+        $secrets = $this->secrets();
+        if ($secrets === []) {
+            return $context;
+        }
+
+        /** @var array<array-key,mixed> $scrubbed */
+        $scrubbed = $this->walk($context, $secrets);
+
+        return $scrubbed;
+    }
+
+    /**
+     * @param  list<string>  $secrets
+     */
+    private function walk(mixed $value, array $secrets): mixed
+    {
+        if (is_string($value)) {
+            return str_replace($secrets, self::MASK, $value);
+        }
+
+        if (is_array($value)) {
+            return array_map(fn (mixed $item): mixed => $this->walk($item, $secrets), $value);
+        }
+
+        if ($value instanceof \Throwable) {
+            // 例外オブジェクトはメッセージ + トレース文字列に展開してから伏字化する。
+            return str_replace($secrets, self::MASK, (string) $value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * 伏字化対象の機密値一覧（空値は対象から除外する）。
+     *
+     * @return list<string>
+     */
+    private function secrets(): array
+    {
+        $candidates = [
+            (string) Config::string('services.notion.secret', ''),
+            (string) Config::string('logging.channels.discord.url', ''),
+            (string) Config::string('database.connections.mysql.password', ''),
+            (string) Config::string('database.connections.portal.password', ''),
+        ];
+
+        return array_values(array_unique(array_filter(
+            $candidates,
+            fn (string $value): bool => $value !== '',
+        )));
+    }
+}

--- a/app/Actions/Logging/SecretScrubber.php
+++ b/app/Actions/Logging/SecretScrubber.php
@@ -66,22 +66,24 @@ final class SecretScrubber
     }
 
     /**
-     * 伏字化対象の機密値一覧（空値は対象から除外する）。
+     * 伏字化対象の機密値一覧（短すぎる値・空値は誤爆防止のため対象から除外する）。
      *
      * @return list<string>
      */
     private function secrets(): array
     {
         $candidates = [
-            (string) Config::string('services.notion.secret', ''),
-            (string) Config::string('logging.channels.discord.url', ''),
-            (string) Config::string('database.connections.mysql.password', ''),
-            (string) Config::string('database.connections.portal.password', ''),
+            Config::get('services.notion.secret'),
+            Config::get('logging.channels.discord.url'),
+            Config::get('database.connections.mysql.password'),
+            Config::get('database.connections.portal.password'),
         ];
 
         return array_values(array_unique(array_filter(
             $candidates,
-            fn (string $value): bool => $value !== '',
+            // 未設定(null)や開発環境の "root" 等の短い値まで伏字化すると
+            // ログ本文を無関係な部分まで壊してしまうため、4文字未満は対象外にする。
+            fn (mixed $value): bool => is_string($value) && mb_strlen($value) >= 4,
         )));
     }
 }

--- a/app/Actions/Logging/SecretScrubber.php
+++ b/app/Actions/Logging/SecretScrubber.php
@@ -64,6 +64,9 @@ final class SecretScrubber
 
         if ($value instanceof \Throwable) {
             // 例外オブジェクトはメッセージ + トレース文字列に展開してから伏字化する。
+            // 注意: これにより context['exception'] は Throwable から string に変わる。
+            // Sentry 等、Throwable のままであることを期待する Monolog processor/handler を
+            // 将来追加する場合は、本プロセッサより前段に置くこと。
             return str_replace($secrets, self::MASK, (string) $value);
         }
 
@@ -92,9 +95,9 @@ final class SecretScrubber
 
         return $this->cachedSecrets = array_values(array_unique(array_filter(
             $candidates,
-            // 未設定(null)や開発環境の "root" 等の短い値まで伏字化すると
-            // ログ本文を無関係な部分まで壊してしまうため、4文字未満は対象外にする。
-            fn (mixed $value): bool => is_string($value) && mb_strlen($value) >= 4,
+            // 未設定(null)や開発環境の "root"(4文字) 等の短い値まで伏字化すると
+            // chroot/uproot 等の無関係な単語まで壊してしまうため、5文字未満は対象外にする。
+            fn (mixed $value): bool => is_string($value) && mb_strlen($value) >= 5,
         )));
     }
 }

--- a/app/Actions/SyncNotion/SyncAction.php
+++ b/app/Actions/SyncNotion/SyncAction.php
@@ -36,75 +36,98 @@ final readonly class SyncAction
 
         $pages = Page::query()->with('paks')->orderBy('last_modified', 'desc')->limit($limit)->get();
 
-        $this->deleteOldNotionPages($pages, $notionPages);
-        $this->addNewNotionPages($database, $pages, $notionPages);
-    }
+        // 1 件の Notion API エラーでバッチ全体を止めず、項目単位で隔離して継続する。
+        $failed = $this->deleteOldNotionPages($pages, $notionPages)
+            + $this->addNewNotionPages($database, $pages, $notionPages);
 
-    /**
-     * @param  Collection<int,Page>  $pages
-     * @param  Collection<int,NotionPage>  $notionPages
-     */
-    private function deleteOldNotionPages(Collection $pages, Collection $notionPages): void
-    {
-        foreach ($notionPages as $notionPage) {
-            $url = $this->getUrlProp($notionPage);
-            $page = $pages->first(fn (Page $page): bool => $page->url === $url);
-            if (! $page) {
-                logger('[NotionService]delete', ['url' => $url]);
-                $this->notion->pages()->delete($notionPage);
-            }
+        if ($failed > 0) {
+            logger()->error('[NotionService] sync completed with failures', ['failed' => $failed]);
         }
     }
 
     /**
      * @param  Collection<int,Page>  $pages
      * @param  Collection<int,NotionPage>  $notionPages
+     * @return int 失敗件数
      */
-    private function addNewNotionPages(Database $database, Collection $pages, Collection $notionPages): void
+    private function deleteOldNotionPages(Collection $pages, Collection $notionPages): int
+    {
+        $failed = 0;
+        foreach ($notionPages as $notionPage) {
+            try {
+                $url = $this->getUrlProp($notionPage);
+                $page = $pages->first(fn (Page $page): bool => $page->url === $url);
+                if (! $page) {
+                    logger('[NotionService]delete', ['url' => $url]);
+                    $this->notion->pages()->delete($notionPage);
+                }
+            } catch (\Throwable $th) {
+                $failed++;
+                logger()->error('[NotionService] delete failed', ['url' => $url ?? null, $th]);
+            }
+        }
+
+        return $failed;
+    }
+
+    /**
+     * @param  Collection<int,Page>  $pages
+     * @param  Collection<int,NotionPage>  $notionPages
+     * @return int 失敗件数
+     */
+    private function addNewNotionPages(Database $database, Collection $pages, Collection $notionPages): int
     {
         $options = $this->getOptions($database);
+        $failed = 0;
         foreach ($pages as $page) {
-            $exists = true;
-            $url = $page->url;
-            $np = $notionPages->first(fn (NotionPage $notionPage): bool => $this->getUrlProp($notionPage) === $url);
-            if (! $np) {
-                $exists = false;
-                $np = NotionPage::create(PageParent::database($database->id));
-            }
+            try {
+                $exists = true;
+                $url = $page->url;
+                $np = $notionPages->first(fn (NotionPage $notionPage): bool => $this->getUrlProp($notionPage) === $url);
+                if (! $np) {
+                    $exists = false;
+                    $np = NotionPage::create(PageParent::database($database->id));
+                }
 
-            $np = $np->changeTitle($page->title)
-                ->addProperty(
-                    self::PAGE_PROP_MAPPING['url'],
-                    Url::create($page->url)
-                )
-                ->addProperty(
-                    self::PAGE_PROP_MAPPING['site_name'],
-                    RichTextProperty::fromString(__('misc.'.$page->site_name->value))
-                )
-                ->addProperty(
-                    self::PAGE_PROP_MAPPING['last_modified'],
-                    Date::create($page->last_modified->toDateTimeImmutable())
-                )
-                ->addProperty(
-                    self::PAGE_PROP_MAPPING['paks'],
-                    MultiSelect::fromOptions(
-                        ...$page
-                            ->paks
-                            ->map(fn (Pak $pak): array|string => __('misc.'.$pak->slug->value))
-                            ->filter(fn (array|string $name): bool => is_string($name))
-                            ->map(fn (string $name) => $options->first(fn ($opt): bool => $name === $opt->name))
-                            ->filter(fn ($pak): bool => ! is_null($pak))
+                $np = $np->changeTitle($page->title)
+                    ->addProperty(
+                        self::PAGE_PROP_MAPPING['url'],
+                        Url::create($page->url)
                     )
-                );
+                    ->addProperty(
+                        self::PAGE_PROP_MAPPING['site_name'],
+                        RichTextProperty::fromString(__('misc.'.$page->site_name->value))
+                    )
+                    ->addProperty(
+                        self::PAGE_PROP_MAPPING['last_modified'],
+                        Date::create($page->last_modified->toDateTimeImmutable())
+                    )
+                    ->addProperty(
+                        self::PAGE_PROP_MAPPING['paks'],
+                        MultiSelect::fromOptions(
+                            ...$page
+                                ->paks
+                                ->map(fn (Pak $pak): array|string => __('misc.'.$pak->slug->value))
+                                ->filter(fn (array|string $name): bool => is_string($name))
+                                ->map(fn (string $name) => $options->first(fn ($opt): bool => $name === $opt->name))
+                                ->filter(fn ($pak): bool => ! is_null($pak))
+                        )
+                    );
 
-            if ($exists) {
-                logger('[NotionService] update', ['url' => $url]);
-                $this->notion->pages()->update($np);
-            } else {
-                logger('[NotionService] create', ['url' => $url]);
-                $this->notion->pages()->create($np);
+                if ($exists) {
+                    logger('[NotionService] update', ['url' => $url]);
+                    $this->notion->pages()->update($np);
+                } else {
+                    logger('[NotionService] create', ['url' => $url]);
+                    $this->notion->pages()->create($np);
+                }
+            } catch (\Throwable $th) {
+                $failed++;
+                logger()->error('[NotionService] sync failed', ['url' => $page->url, $th]);
             }
         }
+
+        return $failed;
     }
 
     private function getUrlProp(NotionPage $notionPage): ?string

--- a/app/Actions/SyncNotion/SyncAction.php
+++ b/app/Actions/SyncNotion/SyncAction.php
@@ -53,12 +53,12 @@ final readonly class SyncAction
     private function deleteOldNotionPages(Collection $pages, Collection $notionPages): int
     {
         $failed = 0;
+        $pagesByUrl = $pages->keyBy('url');
         foreach ($notionPages as $notionPage) {
             $url = null;
             try {
                 $url = $this->getUrlProp($notionPage);
-                $page = $pages->first(fn (Page $page): bool => $page->url === $url);
-                if (! $page) {
+                if ($url === null || ! $pagesByUrl->has($url)) {
                     logger('[NotionService]delete', ['url' => $url]);
                     $this->notion->pages()->delete($notionPage);
                 }

--- a/app/Actions/SyncNotion/SyncAction.php
+++ b/app/Actions/SyncNotion/SyncAction.php
@@ -58,7 +58,8 @@ final readonly class SyncAction
             $url = null;
             try {
                 $url = $this->getUrlProp($notionPage);
-                if ($url === null || ! $pagesByUrl->has($url)) {
+                // url が無い Notion ページ（手動作成の下書き等）は削除対象にしない。
+                if ($url !== null && ! $pagesByUrl->has($url)) {
                     logger('[NotionService]delete', ['url' => $url]);
                     $this->notion->pages()->delete($notionPage);
                 }
@@ -80,11 +81,13 @@ final readonly class SyncAction
     {
         $options = $this->getOptions($database);
         $failed = 0;
+        $notionPagesByUrl = $this->keyNotionPagesByUrl($notionPages);
+
         foreach ($pages as $page) {
             try {
                 $exists = true;
                 $url = $page->url;
-                $np = $notionPages->first(fn (NotionPage $notionPage): bool => $this->getUrlProp($notionPage) === $url);
+                $np = $notionPagesByUrl->get($url);
                 if (! $np) {
                     $exists = false;
                     $np = NotionPage::create(PageParent::database($database->id));
@@ -129,6 +132,30 @@ final readonly class SyncAction
         }
 
         return $failed;
+    }
+
+    /**
+     * url 取得に失敗した Notion ページ（プロパティ欠落等）が 1 件あっても
+     * 残りのページの同期を止めないよう、ここで隔離してマップ化する。
+     *
+     * @param  Collection<int,NotionPage>  $notionPages
+     * @return Collection<string,NotionPage>
+     */
+    private function keyNotionPagesByUrl(Collection $notionPages): Collection
+    {
+        $byUrl = collect();
+        foreach ($notionPages as $notionPage) {
+            try {
+                $url = $this->getUrlProp($notionPage);
+                if ($url !== null) {
+                    $byUrl->put($url, $notionPage);
+                }
+            } catch (\Throwable $th) {
+                logger()->error('[NotionService] failed to read url property', [$th]);
+            }
+        }
+
+        return $byUrl;
     }
 
     private function getUrlProp(NotionPage $notionPage): ?string

--- a/app/Actions/SyncNotion/SyncAction.php
+++ b/app/Actions/SyncNotion/SyncAction.php
@@ -54,6 +54,7 @@ final readonly class SyncAction
     {
         $failed = 0;
         foreach ($notionPages as $notionPage) {
+            $url = null;
             try {
                 $url = $this->getUrlProp($notionPage);
                 $page = $pages->first(fn (Page $page): bool => $page->url === $url);
@@ -63,7 +64,7 @@ final readonly class SyncAction
                 }
             } catch (\Throwable $th) {
                 $failed++;
-                logger()->error('[NotionService] delete failed', ['url' => $url ?? null, $th]);
+                logger()->error('[NotionService] delete failed', ['url' => $url, $th]);
             }
         }
 

--- a/app/Logging/RedactSecretsProcessor.php
+++ b/app/Logging/RedactSecretsProcessor.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Logging;
+
+use App\Actions\Logging\SecretScrubber;
+use Monolog\LogRecord;
+use Monolog\Processor\ProcessorInterface;
+
+/**
+ * ファイルログ（daily / api チャンネル）に書き出す直前に機密値を伏字化する Monolog プロセッサ。
+ * Discord 送出経路は ConvertDiscord 側で別途スクラブする。
+ */
+final readonly class RedactSecretsProcessor implements ProcessorInterface
+{
+    public function __construct(private SecretScrubber $secretScrubber) {}
+
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        return $record->with(
+            message: $this->secretScrubber->scrub($record->message),
+            context: $this->secretScrubber->scrubArray($record->context),
+            extra: $this->secretScrubber->scrubArray($record->extra),
+        );
+    }
+}

--- a/app/Logging/RedactSecretsTap.php
+++ b/app/Logging/RedactSecretsTap.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Logging;
+
+use App\Actions\Logging\SecretScrubber;
+use Illuminate\Log\Logger;
+use Monolog\Logger as MonologLogger;
+
+/**
+ * ログチャンネルに機密値伏字化プロセッサを差し込む tap。
+ * config/logging.php の対象チャンネルの 'tap' に登録する。
+ */
+final class RedactSecretsTap
+{
+    public function __invoke(Logger $logger): void
+    {
+        $monolog = $logger->getLogger();
+        if ($monolog instanceof MonologLogger) {
+            $monolog->pushProcessor(
+                new RedactSecretsProcessor(app(SecretScrubber::class)),
+            );
+        }
+    }
+}

--- a/app/Models/RawPage.php
+++ b/app/Models/RawPage.php
@@ -19,10 +19,12 @@ use Symfony\Component\DomCrawler\Crawler;
  * @property SiteName $site_name
  * @property string $url
  * @property string $html
+ * @property Carbon|null $extract_failed_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Page|null $page
  *
+ * @method static \Database\Factories\RawPageFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RawPage newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RawPage newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|RawPage query()
@@ -38,11 +40,13 @@ final class RawPage extends Model
         'site_name',
         'url',
         'html',
+        'extract_failed_at',
     ];
 
     protected $casts = [
         'site_name' => SiteName::class,
         'html' => CompressedHtml::class,
+        'extract_failed_at' => 'datetime',
     ];
 
     private ?Crawler $crawler = null;

--- a/config/logging.php
+++ b/config/logging.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Logging\RedactSecretsTap;
 use MarvinLabs\DiscordLogger\Logger;
 use Monolog\Handler\StreamHandler;
 use Monolog\Processor\PsrLogMessageProcessor;
@@ -64,6 +65,7 @@ return [
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'replace_placeholders' => true,
+            'tap' => [RedactSecretsTap::class],
         ],
 
         'api' => [
@@ -71,6 +73,7 @@ return [
             'path' => storage_path('logs/api.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'replace_placeholders' => true,
+            'tap' => [RedactSecretsTap::class],
         ],
 
         'slack' => [

--- a/database/migrations/2026_06_22_000000_add_extract_failed_at_to_raw_pages_table.php
+++ b/database/migrations/2026_06_22_000000_add_extract_failed_at_to_raw_pages_table.php
@@ -12,7 +12,8 @@ return new class extends Migration
     {
         Schema::table('raw_pages', function (Blueprint $table): void {
             // 抽出失敗を隔離・可視化する。失敗時に行を削除する代わりにここへ記録する。
-            $table->timestamp('extract_failed_at')->nullable()->after('html');
+            // whereNotNull/whereNull で頻繁に絞り込まれるため index を付与する。
+            $table->timestamp('extract_failed_at')->nullable()->after('html')->index();
         });
     }
 

--- a/database/migrations/2026_06_22_000000_add_extract_failed_at_to_raw_pages_table.php
+++ b/database/migrations/2026_06_22_000000_add_extract_failed_at_to_raw_pages_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('raw_pages', function (Blueprint $table): void {
+            // 抽出失敗を隔離・可視化する。失敗時に行を削除する代わりにここへ記録する。
+            $table->timestamp('extract_failed_at')->nullable()->after('html');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('raw_pages', function (Blueprint $table): void {
+            $table->dropColumn('extract_failed_at');
+        });
+    }
+};

--- a/docs/assurance-audit-2026-06-22.md
+++ b/docs/assurance-audit-2026-06-22.md
@@ -1,0 +1,59 @@
+# Assurance Audit スナップショット（2026-06-22）
+
+これは初回の Assurance Audit（assurance-audit スキル）の診断記録。
+「現在の状態」は [known-risks.md](known-risks.md) を参照。本ファイルは**初回診断の根拠**を残すための凍結記録。
+
+採点モデル: `Intent → Behavior → Control → Evidence`。
+Coverage（量）ではなく **Confidence（守られているか）** を採点する。
+スコープは認証/課金/取引のない公開スクレイピング＋検索アプリとして、ユーザー選択の 4 領域。
+
+---
+
+## Step -1 所見（最優先）
+
+**脅威モデル・既知リスク・runbook が一切存在しない。** `docs/dependency-debt.md` は依存負債のみ。
+「何を守るべきか」の台帳が無いこと自体が最大の欠陥。本監査を機に [known-risks.md](known-risks.md) を新設した。
+
+## New Candidate Risks（脅威探索で発見、既存台帳に無かった項目）
+
+1. **🟡 抽出失敗時に RawPage を削除している (A4)** — `app/Actions/Extract/{Twitrans,Japan,Portal}/Handler.php`
+   の catch で `$rawPage->delete()`。一過性バグでも唯一のスクレイプ結果が恒久消失。
+2. **🟡 例外 → Discord/ログへのスタックトレース素通し (B4/C3)** — `bootstrap/app.php` の空ハンドラ、
+   `config/discord-logger.php` の `'stacktrace' => 'smart'`、`ConvertDiscord` が trace/context を無加工送出。
+   機密値（Notion secret/webhook/DB パスワード）混入経路が開いている。
+3. **🔴 `.env.example` が `APP_DEBUG=true` 既定 (C1)** — redaction 無し、API も独自ハンドリング無し。
+4. **Notion 同期の再同期スロットリング無し (B3)** — 毎回最新 100 件を re-PUSH。データ破損ではなく API クォータ浪費。
+
+---
+
+## 全挙動マトリクス（初回値）
+
+| # | 挙動 → Expected Outcome | 制御 | テスト | Status |
+|---|---|---|---|---|
+| A1 | 1 サイト失敗で他が止まらない | Preventive（try/catch） | 0 | 🔴 Untested |
+| A2 | HTTP 失敗時に空 HTML 上書きしない | Preventive（成功時のみ upsert） | 0 | 🔴 Untested |
+| A3 | extract 再実行で Page 重複なし | Preventive（unique + HasOne） | 0 | 🔴 Untested |
+| A4 | 抽出失敗時にデータ破壊しない | 誤り（delete で消去） | 0 | 🟡 Structural Weakness |
+| A5 | 同一 URL 重複行なし | Preventive（DB 一意制約） | 0 | 🔴 Untested |
+| B1 | 再実行で Notion 重複作成なし | Preventive（URL 突合） | 1 Strong | 🟡 SPOF |
+| B2 | 1 件 API エラーで全体停止しない | None | 0 | 🔴 Missing |
+| B3 | 未変更項目を re-PUSH しない | None | 0 | 🔴 Missing |
+| B4 | 機密値を例外出力に混入させない | Detective のみ | 0 | 🟡 Structural Weakness |
+| C1 | デバッグページが trace を露出しない | None（DEBUG=true 既定） | 0 | 🟡 Structural Weakness |
+| C2 | API 例外が生 trace を返さない | None | 0 | 🔴 Missing |
+| C3 | log/Discord に機密値を混入させない | Detective のみ | 0 | 🟡 Structural Weakness |
+| C4 | git に実シークレット混入なし | Preventive | N/A | 🟢 OK |
+| D1 | raw_pages を公開経路に露出しない | Preventive（eager-load せず） | 0 | 🔴 Untested |
+| D2 | 非公開コンテンツを出さない | N/A（公開状態の概念なし） | — | 対象外 |
+| D3 | 応答に内部フィールドを含めない | Preventive（Resource 許可リスト） | 0 | 🔴 Untested |
+| D4 | 半書き Page を検索に見せない | None（transaction なし） | 0 | 🟡 Structural Weakness |
+
+---
+
+## 所見
+
+- 🟢 は C4（git シークレット混入チェック）のみ。
+- 「Untested」行（A1/A2/A3/A5/D1/D3）は機構自体は健全。回帰検知テストが無いことが欠陥。
+- 最優先の構造的弱点: **A4**（証跡破壊）と **C1+C3/B4**（機密漏洩経路、1 つの修正で複数行を閉じる）。
+- **B2** は最もクリアな Missing Control（scrape/extract と違い項目単位のフォールト分離が皆無）。
+- 機密値が「過去に実際に漏れた痕跡」は発見していない。確認されたのは**開いた経路**であり、過去のインシデントではない。

--- a/docs/known-risks.md
+++ b/docs/known-risks.md
@@ -1,0 +1,53 @@
+# Known Risks（保護すべき挙動の台帳）
+
+「壊れてはいけない挙動」の台帳。1 行＝1 保護挙動。Assurance Audit の採点結果を記録し、
+今後の棚卸し・監査の対象にする（`docs/dependency-debt.md` と同じ運用思想）。
+
+- **制御**: None（無し）/ Detective（事後に検知・通知のみ）/ Preventive（事前に阻止）
+- **Status**: 🔴 Missing/Stale/Weak ・ 🟡 Structural Weakness/SPOF ・ 🟢 OK
+- 是正が完了したら Status とテスト欄を更新する（行は削除せず履歴として残す）。
+- 初回診断の根拠は [assurance-audit-2026-06-22.md](assurance-audit-2026-06-22.md) を参照。
+
+## A. Scrape / Extract パイプライン
+
+| ID | 保護すべき挙動 / Expected Outcome | 制御 | テスト | Status | 是正条件 | 記録日 |
+|----|----------------------------------|------|--------|--------|----------|--------|
+| A1 | 1 サイト/1URL の失敗で他サイト・他 URL の処理が止まらない | Preventive（ハンドラ毎の try/catch） | 1（`Extract/Japan/HandlerIsolationTest`） | 🟡 SPOF | テストを 2 本以上に（scrape 側 / 他サイトにも展開） | 2026-06-22 |
+| A2 | HTTP 失敗時に RawPage を空/部分 HTML で上書きしない | Preventive（fetch 例外時は upsert に到達しない） | 1（`Scrape/Japan/HandlerFailureTest`） | 🟡 SPOF | 残課題: 非2xx でも body を書き込む経路がある。`->throw()` 等で非2xx も失敗扱いにするか検討 | 2026-06-22 |
+| A3 | 同一 RawPage に extract を再実行しても Page 重複が出ない（冪等） | Preventive（`pages_url_unique` + HasOne） | 1（`Extract/UpdateOrCreatePageTest`） | 🟡 SPOF | テストを 2 本以上に | 2026-06-22 |
+| A4 | 抽出失敗時にスクレイプ済データ（RawPage）を破壊しない | Preventive（`MarkExtractFailed`：削除せず `extract_failed_at` で隔離、成功時にクリア） | 4（`MarkExtractFailedTest`×3 + `HandlerIsolationTest`） | 🟢 OK | — | 2026-06-22 |
+| A5 | 同一 URL の重複行を作らない | Preventive（DB 一意制約） | 2（`Models/UrlUniqueConstraintTest`） | 🟢 OK | — | 2026-06-22 |
+
+## B. Notion 同期
+
+| ID | 保護すべき挙動 / Expected Outcome | 制御 | テスト | Status | 是正条件 | 記録日 |
+|----|----------------------------------|------|--------|--------|----------|--------|
+| B1 | 再実行で Notion ページを重複作成しない | Preventive（URL 突合で create/update 分岐） | 1（Strong） | 🟡 SPOF | テストを 2 本以上に増やす | 2026-06-22 |
+| B2 | 1 件の Notion API エラーでバッチ全体が止まらない | Preventive（項目単位 try/catch + 継続 + 失敗件数を error ログ） | 1（`SyncActionTest::test_continues_syncing_when_one_item_fails`） | 🟡 SPOF | テストを 2 本以上に（delete 側の失敗継続も） | 2026-06-22 |
+| B3 | 未変更項目を毎回 re-PUSH せず API クォータを浪費しない | None（`synced_at`/状態フラグ無し） | 0 | 🔴 Missing | **記録のみ**。API 呼び出し回数が問題化したら `synced_at` を導入 | 2026-06-22 |
+| B4 | Notion シークレットを例外/ログ/Discord に流出させない | Preventive（`SecretScrubber` で送出前に伏字化。C3 と一体） | 4（C3 のテストと共有） | 🟢 OK | — | 2026-06-22 |
+
+## C. シークレット / 資格情報の取扱い
+
+| ID | 保護すべき挙動 / Expected Outcome | 制御 | テスト | Status | 是正条件 | 記録日 |
+|----|----------------------------------|------|--------|--------|----------|--------|
+| C1 | デバッグページが config/スタックトレースを露出しない | Preventive（`.env.example`/`.ci`/`.deploy` すべて `APP_DEBUG=false`、コード既定も false） | 1（C2 の `ApiErrorResponseTest` で間接担保） | 🟡 SPOF | Web 側デバッグページ向けの直接テストは未追加 | 2026-06-22 |
+| C2 | API 例外が生のトレースを返さない | Preventive（`APP_DEBUG=false` で汎用 JSON エラー） | 1（`Http/ApiErrorResponseTest`） | 🟡 SPOF | テストを 2 本以上に | 2026-06-22 |
+| C3 | 例外レポート（log/Discord）に機密値を混入させない | Preventive（`SecretScrubber` + `RedactSecretsProcessor`/tap + `ConvertDiscord` で送出前に伏字化） | 4（`SecretScrubberTest`×3 + `RedactSecretsProcessorTest`） | 🟢 OK | — | 2026-06-22 |
+| C4 | 実シークレットを git に混入させない | Preventive（`.gitignore` で `.env` 除外、committed な `.env.*` は空値） | N/A | 🟢 OK | — | 2026-06-22 |
+
+## D. 公開検索 / Feed / API
+
+| ID | 保護すべき挙動 / Expected Outcome | 制御 | テスト | Status | 是正条件 | 記録日 |
+|----|----------------------------------|------|--------|--------|----------|--------|
+| D1 | raw_pages（生 HTML）を公開経路に露出しない | Preventive（検索/Feed で rawPage を eager-load しない、Page に html 列無し） | 1（`PageResourceTest::test_search_does_not_eager_load_raw_page_relation`） | 🟡 SPOF | Feed 経路の assert も追加 | 2026-06-22 |
+| D2 | 非公開コンテンツを検索/Feed に出さない | N/A（Page に公開状態の概念が無い） | — | — | 対象外（将来 status 列を足す場合は再評価） | 2026-06-22 |
+| D3 | API/Feed 応答に内部フィールドを含めない | Preventive（PageResource 許可リスト） | 1（`PageResourceTest::test_resource_exposes_only_whitelisted_fields`） | 🟡 SPOF | テストを 2 本以上に | 2026-06-22 |
+| D4 | 半分書かれた Page 行を検索に見せない（原子性） | None（`UpdateOrCreatePage` に transaction 無し） | 0 | 🟡 Structural Weakness | （低優先・データ品質）将来 transaction か status 列で是正 | 2026-06-22 |
+
+<!--
+運用メモ:
+- この台帳は Assurance Audit（assurance-audit スキル）の採点結果を反映する。
+- Coverage（量）ではなく Confidence（守られているか）を追跡する台帳。
+- 改修完了行は Status を 🟢/🟡 に更新し、テスト欄に本数を反映する。
+-->

--- a/tests/Feature/Actions/Extract/Japan/HandlerIsolationTest.php
+++ b/tests/Feature/Actions/Extract/Japan/HandlerIsolationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Extract\Japan;
+
+use App\Actions\Extract\ChunkRawPages;
+use App\Actions\Extract\Japan\ExtractContents;
+use App\Actions\Extract\Japan\ExtractLastModified;
+use App\Actions\Extract\Japan\Handler;
+use App\Actions\Extract\MarkExtractFailed;
+use App\Actions\Extract\SyncPak;
+use App\Actions\Extract\UpdateOrCreatePage;
+use App\Enums\SiteName;
+use App\Models\RawPage;
+use Psr\Log\NullLogger;
+use Tests\Feature\TestCase;
+
+/**
+ * A1: 1 件の抽出失敗で他の RawPage 処理が止まらないこと（フォールト分離）。
+ * A4: 失敗した RawPage は削除されず失敗フラグが立つこと。
+ */
+final class HandlerIsolationTest extends TestCase
+{
+    public function test_failure_on_one_raw_page_does_not_stop_the_others(): void
+    {
+        // div#lastmodified が無いため ExtractLastModified が自然に失敗する。
+        $rawPageA = RawPage::factory()->create([
+            'site_name' => SiteName::Japan,
+            'url' => 'https://japanese.simutrans.com/index.php?Addon128%2FBroken',
+            'html' => '<html><body><div id="body">no lastmodified here</div></body></html>',
+        ]);
+
+        // 正常に抽出できる HTML。
+        $rawPageB = RawPage::factory()->create([
+            'site_name' => SiteName::Japan,
+            'url' => 'https://japanese.simutrans.com/index.php?Addon128%2FOk',
+            'html' => '<html><head><title>OK Addon - Simutrans日本語化･解説</title></head>'
+                .'<body><div id="body">本文</div><div id="lastmodified">Last-modified: 2024-01-01 00:00:00 (月)</div></body></html>',
+        ]);
+
+        $handler = new Handler(
+            new ChunkRawPages,
+            new ExtractLastModified,
+            new ExtractContents,
+            new UpdateOrCreatePage,
+            new SyncPak,
+            new MarkExtractFailed,
+        );
+
+        $handler(new NullLogger);
+
+        // b は失敗した a の後でも処理され、Page が作られる。
+        $this->assertDatabaseHas('pages', ['raw_page_id' => $rawPageB->id]);
+        $this->assertDatabaseMissing('pages', ['raw_page_id' => $rawPageA->id]);
+
+        // a は削除されず、失敗フラグが立つ。b はフラグなし。
+        $this->assertDatabaseHas('raw_pages', ['id' => $rawPageA->id]);
+        $this->assertNotNull($rawPageA->fresh()?->extract_failed_at);
+        $this->assertNull($rawPageB->fresh()?->extract_failed_at);
+    }
+}

--- a/tests/Feature/Actions/Extract/MarkExtractFailedTest.php
+++ b/tests/Feature/Actions/Extract/MarkExtractFailedTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Extract;
+
+use App\Actions\Extract\MarkExtractFailed;
+use App\Models\RawPage;
+use Psr\Log\NullLogger;
+use Tests\Feature\TestCase;
+
+/**
+ * A4: 抽出失敗時にスクレイプ済データ（RawPage）を破壊しない。
+ */
+final class MarkExtractFailedTest extends TestCase
+{
+    public function test_marks_failure_without_deleting_raw_page(): void
+    {
+        $rawPage = RawPage::factory()->create();
+
+        (new MarkExtractFailed)(new NullLogger, $rawPage, new \RuntimeException('parse error'));
+
+        // 削除されず残存していること（旧実装は delete() で消していた）。
+        $this->assertDatabaseHas('raw_pages', ['id' => $rawPage->id]);
+        $this->assertNotNull($rawPage->fresh()?->extract_failed_at);
+    }
+
+    public function test_clear_resets_failed_flag_on_success(): void
+    {
+        $rawPage = RawPage::factory()->create(['extract_failed_at' => now()]);
+
+        (new MarkExtractFailed)->clear($rawPage);
+
+        $this->assertNull($rawPage->fresh()?->extract_failed_at);
+    }
+
+    public function test_clear_is_noop_when_not_failed(): void
+    {
+        $rawPage = RawPage::factory()->create(['extract_failed_at' => null]);
+
+        (new MarkExtractFailed)->clear($rawPage);
+
+        $this->assertNull($rawPage->fresh()?->extract_failed_at);
+    }
+}

--- a/tests/Feature/Actions/Extract/UpdateOrCreatePageTest.php
+++ b/tests/Feature/Actions/Extract/UpdateOrCreatePageTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Extract;
+
+use App\Actions\Extract\UpdateOrCreatePage;
+use App\Models\Page;
+use App\Models\RawPage;
+use Carbon\CarbonImmutable;
+use Tests\Feature\TestCase;
+
+/**
+ * A3: 同一 RawPage に対して extract を再実行しても Page が重複しない（冪等）。
+ */
+final class UpdateOrCreatePageTest extends TestCase
+{
+    public function test_running_twice_keeps_a_single_page(): void
+    {
+        $rawPage = RawPage::factory()->create();
+        $updateOrCreatePage = new UpdateOrCreatePage;
+
+        $page = $updateOrCreatePage($rawPage, 'タイトル', '本文', CarbonImmutable::now());
+        $second = $updateOrCreatePage($rawPage->fresh(), 'タイトル更新', '本文更新', CarbonImmutable::now());
+
+        // 行は 1 件のまま、同一 Page が更新される。
+        $this->assertSame(1, Page::query()->where('raw_page_id', $rawPage->id)->count());
+        $this->assertSame($page->id, $second->id);
+        $this->assertSame('タイトル更新', $second->fresh()?->title);
+    }
+}

--- a/tests/Feature/Actions/Logging/ConvertDiscordTest.php
+++ b/tests/Feature/Actions/Logging/ConvertDiscordTest.php
@@ -20,10 +20,10 @@ final class ConvertDiscordTest extends TestCase
     {
         Config::set('services.notion.secret', 'ntn_supersecret');
 
-        $converter = new ConvertDiscord(app('config'), new SecretScrubber);
+        $convertDiscord = new ConvertDiscord(app('config'), new SecretScrubber);
         $message = Message::make();
 
-        $this->callProtected($converter, 'addMessageContent', [$message, $this->record()]);
+        $this->callProtected($convertDiscord, 'addMessageContent', [$message, $this->record()]);
 
         // スタックトレースが取得・添付されていること（先に scrub していたら null になっていたはず）。
         $this->assertNotNull($message->file);
@@ -32,12 +32,12 @@ final class ConvertDiscordTest extends TestCase
 
     public function test_inherited_add_message_stacktrace_does_not_overwrite_with_raw_trace(): void
     {
-        $converter = new ConvertDiscord(app('config'), new SecretScrubber);
+        $convertDiscord = new ConvertDiscord(app('config'), new SecretScrubber);
         $message = Message::make();
         $message->file('[REDACTED-SENTINEL]', 'f.txt');
 
         // 親クラスの addMessageStacktrace が未伏字化の生トレースで上書きしないこと（no-op であること）。
-        $this->callProtected($converter, 'addMessageStacktrace', [$message, $this->record()]);
+        $this->callProtected($convertDiscord, 'addMessageStacktrace', [$message, $this->record()]);
 
         $this->assertSame('[REDACTED-SENTINEL]', $message->file['contents']);
     }
@@ -56,8 +56,8 @@ final class ConvertDiscordTest extends TestCase
 
     private function callProtected(object $object, string $method, array $args): mixed
     {
-        $reflection = new \ReflectionMethod($object, $method);
+        $reflectionMethod = new \ReflectionMethod($object, $method);
 
-        return $reflection->invoke($object, ...$args);
+        return $reflectionMethod->invoke($object, ...$args);
     }
 }

--- a/tests/Feature/Actions/Logging/ConvertDiscordTest.php
+++ b/tests/Feature/Actions/Logging/ConvertDiscordTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Logging;
+
+use App\Actions\Logging\ConvertDiscord;
+use App\Actions\Logging\SecretScrubber;
+use Illuminate\Support\Facades\Config;
+use MarvinLabs\DiscordLogger\Discord\Message;
+use Tests\Feature\TestCase;
+
+/**
+ * C3 / B4: Discord 送出経路の全体（addMessageContent + addMessageStacktrace）を通して
+ * 機密値が漏れないこと。
+ */
+final class ConvertDiscordTest extends TestCase
+{
+    public function test_stacktrace_is_extracted_even_though_context_gets_scrubbed(): void
+    {
+        Config::set('services.notion.secret', 'ntn_supersecret');
+
+        $converter = new ConvertDiscord(app('config'), new SecretScrubber);
+        $message = Message::make();
+
+        $this->callProtected($converter, 'addMessageContent', [$message, $this->record()]);
+
+        // スタックトレースが取得・添付されていること（先に scrub していたら null になっていたはず）。
+        $this->assertNotNull($message->file);
+        $this->assertStringNotContainsString('ntn_supersecret', (string) ($message->content ?? ''));
+    }
+
+    public function test_inherited_add_message_stacktrace_does_not_overwrite_with_raw_trace(): void
+    {
+        $converter = new ConvertDiscord(app('config'), new SecretScrubber);
+        $message = Message::make();
+        $message->file('[REDACTED-SENTINEL]', 'f.txt');
+
+        // 親クラスの addMessageStacktrace が未伏字化の生トレースで上書きしないこと（no-op であること）。
+        $this->callProtected($converter, 'addMessageStacktrace', [$message, $this->record()]);
+
+        $this->assertSame('[REDACTED-SENTINEL]', $message->file['contents']);
+    }
+
+    private function record(): array
+    {
+        return [
+            'datetime' => new \DateTime,
+            'level_name' => 'ERROR',
+            'message' => 'sync failed with ntn_supersecret',
+            'context' => [
+                'exception' => new \RuntimeException('boom'),
+            ],
+        ];
+    }
+
+    private function callProtected(object $object, string $method, array $args): mixed
+    {
+        $reflection = new \ReflectionMethod($object, $method);
+
+        return $reflection->invoke($object, ...$args);
+    }
+}

--- a/tests/Feature/Actions/Logging/SecretScrubberTest.php
+++ b/tests/Feature/Actions/Logging/SecretScrubberTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Logging;
+
+use App\Actions\Logging\SecretScrubber;
+use Illuminate\Support\Facades\Config;
+use Tests\Feature\TestCase;
+
+/**
+ * C3 / B4: ログ・Discord 送出経路に既知の機密値が混入しないこと。
+ */
+final class SecretScrubberTest extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('services.notion.secret', 'ntn_supersecret');
+        Config::set('logging.channels.discord.url', 'https://discord.com/api/webhooks/abc/xyz');
+        Config::set('database.connections.mysql.password', 'db-pass-123');
+    }
+
+    public function test_scrub_masks_known_secrets_in_strings(): void
+    {
+        $secretScrubber = new SecretScrubber;
+
+        $result = $secretScrubber->scrub('Authorization: Bearer ntn_supersecret failed for db-pass-123');
+
+        $this->assertStringNotContainsString('ntn_supersecret', $result);
+        $this->assertStringNotContainsString('db-pass-123', $result);
+        $this->assertStringContainsString('[REDACTED]', $result);
+    }
+
+    public function test_scrub_array_recurses_and_masks_throwable(): void
+    {
+        $secretScrubber = new SecretScrubber;
+
+        $result = $secretScrubber->scrubArray([
+            'url' => 'https://discord.com/api/webhooks/abc/xyz',
+            'nested' => ['token' => 'value=ntn_supersecret'],
+            'exception' => new \RuntimeException('leaked ntn_supersecret here'),
+        ]);
+
+        $encoded = json_encode($result);
+        $this->assertIsString($encoded);
+        $this->assertStringNotContainsString('ntn_supersecret', $encoded);
+        $this->assertStringNotContainsString('discord.com/api/webhooks/abc/xyz', $encoded);
+    }
+
+    public function test_scrub_is_noop_when_no_secrets_configured(): void
+    {
+        Config::set('services.notion.secret', '');
+        Config::set('logging.channels.discord.url', '');
+        Config::set('database.connections.mysql.password', '');
+        Config::set('database.connections.portal.password', '');
+
+        $secretScrubber = new SecretScrubber;
+
+        // 空の機密値で全文が伏字化されてしまわないこと。
+        $this->assertSame('plain text', $secretScrubber->scrub('plain text'));
+    }
+}

--- a/tests/Feature/Actions/Logging/SecretScrubberTest.php
+++ b/tests/Feature/Actions/Logging/SecretScrubberTest.php
@@ -50,6 +50,17 @@ final class SecretScrubberTest extends TestCase
         $this->assertStringNotContainsString('discord.com/api/webhooks/abc/xyz', $encoded);
     }
 
+    public function test_scrub_does_not_mangle_common_words_when_secret_is_short(): void
+    {
+        Config::set('database.connections.mysql.password', 'root');
+
+        $secretScrubber = new SecretScrubber;
+
+        // "root"(4文字) のような開発環境の短いパスワードは伏字化対象に含めない。
+        // chroot/uproot 等の無関係な単語まで破壊してしまうため。
+        $this->assertSame('chroot jail for root', $secretScrubber->scrub('chroot jail for root'));
+    }
+
     public function test_scrub_is_noop_when_no_secrets_configured(): void
     {
         Config::set('services.notion.secret', '');

--- a/tests/Feature/Actions/Scrape/Japan/HandlerFailureTest.php
+++ b/tests/Feature/Actions/Scrape/Japan/HandlerFailureTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Actions\Scrape\Japan;
+
+use App\Actions\Scrape\FetchHtml;
+use App\Actions\Scrape\Japan\FindUrls;
+use App\Actions\Scrape\Japan\Handler;
+use App\Actions\Scrape\UpdateOrCreateRawPage;
+use App\Models\RawPage;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Psr\Log\NullLogger;
+use Tests\Feature\TestCase;
+
+/**
+ * A2: 取得失敗時に RawPage を空/部分データで書き込まない。
+ * fetch が例外を投げた URL は upsert に到達せず、行が作られないこと。
+ */
+final class HandlerFailureTest extends TestCase
+{
+    public function test_does_not_write_raw_page_when_fetch_fails(): void
+    {
+        Http::preventStrayRequests();
+
+        $listHtml = '<html><body><div id="body"><ul><li>'
+            .'<a href="https://japanese.simutrans.com:443/index.php?Addon128%2FTest">test</a>'
+            .'</li></ul></div></body></html>';
+
+        Http::fake([
+            'https://japanese.simutrans.com?cmd=list' => Http::response($listHtml, 200),
+            // PSR-7 URI は文字列化時に既定ポート(443)を省略するため、
+            // Http::fake のキーは href の表記（:443 付き）ではなく実際の送信先 URL に合わせる。
+            'https://japanese.simutrans.com/index.php?Addon128%2FTest' => fn (): never => throw new ConnectionException('connection failed'),
+        ]);
+
+        $handler = new Handler(
+            new FetchHtml(retryTimes: 1, sleepMilliseconds: 1, useCache: false),
+            new FindUrls(new FetchHtml(retryTimes: 1, sleepMilliseconds: 1, useCache: false)),
+            new UpdateOrCreateRawPage,
+        );
+
+        $handler(new NullLogger);
+
+        $this->assertSame(0, RawPage::query()->count());
+    }
+}

--- a/tests/Feature/Actions/SyncNotion/SyncActionTest.php
+++ b/tests/Feature/Actions/SyncNotion/SyncActionTest.php
@@ -93,4 +93,64 @@ final class SyncActionTest extends TestCase
         $syncAction = new SyncAction($mock);
         $syncAction('test_database_id', 10);
     }
+
+    /**
+     * B2: 1 件の Notion API エラーでバッチ全体が止まらず、残り項目が処理されること。
+     */
+    public function test_continues_syncing_when_one_item_fails(): void
+    {
+        Page::factory()->create([
+            'title' => 'Fails',
+            'site_name' => SiteName::Japan,
+            'url' => 'https://example.com/fail',
+            'last_modified' => now()->subDay(),
+        ]);
+        Page::factory()->create([
+            'title' => 'Succeeds',
+            'site_name' => SiteName::Japan,
+            'url' => 'https://example.com/ok',
+            'last_modified' => now(),
+        ]);
+
+        $database = Database::fromArray([
+            'id' => 'test_database_id',
+            'created_time' => '2023-01-01T00:00:00.000Z',
+            'last_edited_time' => '2023-01-01T00:00:00.000Z',
+            'title' => [],
+            'description' => [],
+            'icon' => null,
+            'cover' => null,
+            'properties' => [
+                'Title' => ['id' => 'title', 'type' => 'title', 'name' => 'Title', 'title' => []],
+                'パックセット' => [
+                    'id' => 'prop_id',
+                    'type' => 'multi_select',
+                    'name' => 'パックセット',
+                    'multi_select' => ['options' => []],
+                ],
+            ],
+            'parent' => ['type' => 'workspace', 'workspace' => true],
+            'url' => 'https://notion.so',
+            'is_inline' => false,
+        ]);
+
+        $mock = Mockery::mock(Notion::class);
+        $mock->shouldReceive('databases->find')->with('test_database_id')->andReturn($database);
+        $mock->shouldReceive('databases->queryAllPages')->with($database)->andReturn([]);
+
+        // 1 件目（fail）は Notion API がエラーを投げる。
+        $mock->shouldReceive('pages->create')
+            ->with(Mockery::on(fn (NotionPage $notionPage): bool => $notionPage->getProperty('URL')->url === 'https://example.com/fail'))
+            ->andThrow(new \RuntimeException('rate limited'));
+
+        // 2 件目（ok）は 1 件目の失敗後も必ず処理される。
+        $mock->shouldReceive('pages->create')
+            ->once()
+            ->with(Mockery::on(fn (NotionPage $notionPage): bool => $notionPage->getProperty('URL')->url === 'https://example.com/ok'));
+
+        $syncAction = new SyncAction($mock);
+
+        // バッチ全体が中断せず正常終了すること（例外が伝播しない）。
+        $syncAction('test_database_id', 10);
+    }
 }

--- a/tests/Feature/Http/ApiErrorResponseTest.php
+++ b/tests/Feature/Http/ApiErrorResponseTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http;
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use Tests\Feature\TestCase;
+
+/**
+ * C2: 本番モード（APP_DEBUG=false）で API 例外応答にスタックトレースや
+ * 例外メッセージが含まれないこと。
+ */
+final class ApiErrorResponseTest extends TestCase
+{
+    public function test_exception_response_does_not_leak_trace_in_production_mode(): void
+    {
+        Config::set('app.debug', false);
+
+        Route::get('/__test/throw', function (): never {
+            throw new \RuntimeException('super-secret-detail-xyz');
+        });
+
+        $testResponse = $this->getJson('/__test/throw');
+
+        $testResponse->assertStatus(500);
+        $testResponse->assertJsonMissingPath('trace');
+        $testResponse->assertJsonMissingPath('exception');
+        // 汎用メッセージのみで、例外の中身が露出しないこと。
+        $this->assertSame('Server Error', $testResponse->json('message'));
+        $this->assertStringNotContainsString('super-secret-detail-xyz', $testResponse->getContent() ?: '');
+    }
+}

--- a/tests/Feature/Http/Resources/PageResourceTest.php
+++ b/tests/Feature/Http/Resources/PageResourceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Resources;
+
+use App\Actions\SearchPage\SearchAction;
+use App\Enums\PakSlug;
+use App\Enums\SiteName;
+use App\Http\Resources\PageResource;
+use App\Models\Page;
+use App\Models\Pak;
+use App\Models\RawPage;
+use Illuminate\Http\Request;
+use Tests\Feature\TestCase;
+
+/**
+ * D3: API/Feed 応答に内部フィールドを含めない（許可リストのみ）。
+ * D1: 検索結果に raw_pages（生 HTML）を露出しない。
+ */
+final class PageResourceTest extends TestCase
+{
+    public function test_resource_exposes_only_whitelisted_fields(): void
+    {
+        $rawPage = RawPage::factory()->create(['html' => '<html>secret-internal-html</html>']);
+        $page = Page::factory()->create([
+            'raw_page_id' => $rawPage->id,
+            'site_name' => SiteName::Japan,
+        ]);
+
+        $array = (new PageResource($page))->toArray(Request::create('/'));
+
+        $this->assertSame(['title', 'site', 'paks', 'url', 'last_modified'], array_keys($array));
+        $this->assertArrayNotHasKey('raw_page_id', $array);
+        $this->assertArrayNotHasKey('id', $array);
+        $this->assertArrayNotHasKey('text', $array);
+        $this->assertStringNotContainsString('secret-internal-html', (string) json_encode($array));
+    }
+
+    public function test_search_does_not_eager_load_raw_page_relation(): void
+    {
+        $pak = Pak::factory()->create(['slug' => PakSlug::Pak128]);
+        $page = Page::factory()->create([
+            'site_name' => SiteName::Japan,
+            'title' => 'Addon',
+            'text' => 'body',
+        ]);
+        $page->paks()->attach($pak);
+
+        $result = (new SearchAction)([
+            'keyword' => '',
+            'paks' => [PakSlug::Pak128->value],
+            'sites' => [SiteName::Japan->value],
+        ]);
+
+        $this->assertCount(1, $result->items());
+        // 生 HTML を持つ rawPage リレーションがロードされていないこと。
+        $this->assertFalse($result->items()[0]->relationLoaded('rawPage'));
+    }
+}

--- a/tests/Feature/Logging/RedactSecretsProcessorTest.php
+++ b/tests/Feature/Logging/RedactSecretsProcessorTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Logging;
+
+use App\Actions\Logging\SecretScrubber;
+use App\Logging\RedactSecretsProcessor;
+use Illuminate\Support\Facades\Config;
+use Monolog\DateTimeImmutable;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Tests\Feature\TestCase;
+
+/**
+ * C3 / B4: ファイルログ書き込み直前に機密値が伏字化されること。
+ */
+final class RedactSecretsProcessorTest extends TestCase
+{
+    public function test_processor_scrubs_message_and_context(): void
+    {
+        Config::set('services.notion.secret', 'ntn_supersecret');
+
+        $redactSecretsProcessor = new RedactSecretsProcessor(new SecretScrubber);
+
+        $logRecord = new LogRecord(
+            datetime: new DateTimeImmutable(true),
+            channel: 'daily',
+            level: Level::Error,
+            message: 'failed with ntn_supersecret',
+            context: ['detail' => 'token=ntn_supersecret'],
+            extra: [],
+        );
+
+        $result = $redactSecretsProcessor($logRecord);
+
+        $this->assertStringNotContainsString('ntn_supersecret', $result->message);
+        $this->assertStringNotContainsString('ntn_supersecret', (string) json_encode($result->context));
+        $this->assertStringContainsString('[REDACTED]', $result->message);
+    }
+}

--- a/tests/Feature/Models/UrlUniqueConstraintTest.php
+++ b/tests/Feature/Models/UrlUniqueConstraintTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Models\Page;
+use App\Models\RawPage;
+use Illuminate\Database\QueryException;
+use Tests\Feature\TestCase;
+
+/**
+ * A5: 同一 URL の重複行を作らない（DB 一意制約が有効であること）。
+ */
+final class UrlUniqueConstraintTest extends TestCase
+{
+    public function test_raw_pages_url_is_unique(): void
+    {
+        RawPage::factory()->create(['url' => 'https://example.com/dup']);
+
+        $this->expectException(QueryException::class);
+        RawPage::factory()->create(['url' => 'https://example.com/dup']);
+    }
+
+    public function test_pages_url_is_unique(): void
+    {
+        Page::factory()->create(['url' => 'https://example.com/dup']);
+
+        $this->expectException(QueryException::class);
+        Page::factory()->create(['url' => 'https://example.com/dup']);
+    }
+}


### PR DESCRIPTION
## Summary

This repo had no threat model or known-risks ledger. I ran an Assurance
Audit across four areas (scrape/extract pipeline, Notion sync, secret
handling, public search/feed) and used the findings to (1) establish a
continuing ledger and (2) fix the highest-priority gaps in priority order.

- **[docs/known-risks.md](docs/known-risks.md)** — continuing ledger of protected behaviors (A1–D4) with
  control strength / test count / Status, to be revisited on future audits.
- **[docs/assurance-audit-2026-06-22.md](docs/assurance-audit-2026-06-22.md)** — frozen snapshot of the initial audit
  (New Candidate Risks + full matrix).

### Fixes (priority order)

1. **Extract handlers no longer delete RawPage on extraction failure.**
   The previous code called `$rawPage->delete()` on any extraction error,
   permanently destroying the only scraped copy on a transient bug.
   Failures are now isolated via a new `extract_failed_at` flag
   (`MarkExtractFailed`), cleared automatically on the next successful run.
2. **`.env.example` now defaults `APP_DEBUG=false`**, closing the
   debug-page secret-leak path (`.env.ci`/`.env.deploy` were already
   correct).
3. **Added `SecretScrubber`** plus a Monolog tap (`daily`/`api` channels)
   and a `ConvertDiscord` scrub step, so known secrets (Notion token,
   Discord webhook URL, DB passwords) are masked before reaching log
   files or the Discord webhook.
4. **Notion sync (`SyncAction`) now isolates per-item failures** instead
   of aborting the whole batch on one Notion API error; failure count is
   reported.
5. **Added regression tests** for controls that were structurally sound
   but had zero test coverage: per-site/per-URL fault isolation, extract
   idempotency, DB URL-uniqueness constraints, `PageResource` field
   whitelist (no raw HTML/internal fields leak to the API), and API error
   response shape in production mode.

### Known residual gap (recorded, not fixed)

- **B3** (Notion re-sync throttling): no `synced_at`/status flag, so
  unchanged items get re-pushed every run. Recorded in the ledger with a
  revisit condition rather than implemented now (API-quota waste, not data
  corruption).
- **A2**: the upsert-only-on-success path protects against connection
  failures, but a non-2xx HTTP response that doesn't throw could still
  write its body. Noted in the ledger's 是正条件 for `A2`.

## Test plan

- [x] `vendor/bin/pint --dirty` — passed
- [x] `composer stan` (PHPStan level 9, `app/`) — no errors
- [x] `php artisan test` — 39 passed, 94 assertions, against an isolated
  `cs_test` database (not the dev `cs` database)
- [x] Verified the new `extract_failed_at` flag is set/cleared correctly
  and that a second RawPage still processes after the first one fails
  (`HandlerIsolationTest`)
- [x] Verified Notion sync continues past a single item's API failure
  (`SyncActionTest::test_continues_syncing_when_one_item_fails`)
- [x] Verified secrets configured via `Config::set` do not appear in
  scrubbed log/Discord output (`SecretScrubberTest`,
  `RedactSecretsProcessorTest`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)