### PR TITLE
refactor: Pages ビューを責務ごとにパーシャル分割

### DIFF
--- a/resources/views/livewire/pages.blade.php
+++ b/resources/views/livewire/pages.blade.php
@@ -1,50 +1,9 @@
 <div>
-    <div class="mb-2">
-        @foreach (App\Enums\PakSlug::cases() as $pak)
-        <label class="leading-6 text-gray-900 pr-3 font-medium dark:text-white">
-            <input type="checkbox" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600" wire:model="paks.{{$pak->value}}" />
-            {{__('misc.'.$pak->value)}}</label>
-        @endforeach
+    @include('livewire.partials.pages-filter')
 
-        @foreach (App\Enums\SiteName::cases() as $site)
-        <label class="leading-6 text-gray-900 pr-3 font-medium dark:text-white">
-            <input type="checkbox" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600" wire:model="sites.{{$site->value}}" />{{__('misc.'.$site->value)}}</label>
-        @endforeach
-    </div>
-    <div class="inline-flex rounded-md shadow-sm" role="group">
-        <input type="text" id="keyword" class="px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-s-lg hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:hover:text-white dark:hover:bg-gray-700" placeholder="キーワード" wire:model="keyword" wire:keydown.enter="onConditionUpdate" />
-        <button type="button" class="px-4 py-2 text-sm font-medium text-gray-900 bg-white border-t border-b border-gray-200 hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:hover:text-white dark:hover:bg-gray-700" wire:click="onConditionUpdate">検索</button>
-        <button type="button" class="px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-e-lg hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:hover:text-white dark:hover:bg-gray-700" wire:click="clear">リセット</button>
-    </div>
-    @error('keyword')
-        <p class="text-xs text-red-600 dark:text-red-400">{{ $message }}</p>
-    @enderror
+    @include('livewire.partials.pages-pagination')
 
-    <div class="my-4">
-        {{ $this->pages->onEachSide(1)->links('tailwind_custom') }}
-    </div>
+    @include('livewire.partials.pages-results')
 
-    <ul>
-        @forelse ($this->pages as $page)
-        <li class="my-2">
-            <div>
-                @foreach ($page->paks as $pak)
-                <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">{{ __('misc.'.$pak->slug->value) }}</span>
-                @endforeach
-
-                <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">{{ __('misc.'.$page->site_name->value) }}</span>
-
-                <a target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-500 hover:underline" href="{{ $page->url }}">{{ $page->title }}</a>
-
-                <span class="text-xs font-medium text-gray-600 dark:text-gray-300">{{ $page->last_modified->toDateTimeString() }}</span>
-            </div>
-            <div class="text-gray-900 text-sm px-5 py-2.5 dark:text-white">{{ $page->getSummary(300) }}</div>
-        </li>
-        @empty
-        <li class="my-2">該当なし</li>
-        @endforelse
-    </ul>
-    <div class="my-4">
-        {{ $this->pages->onEachSide(1)->links('tailwind_custom') }}
-    </div>
+    @include('livewire.partials.pages-pagination')
 </div>

--- a/resources/views/livewire/partials/pages-filter.blade.php
+++ b/resources/views/livewire/partials/pages-filter.blade.php
@@ -1,0 +1,20 @@
+<div class="mb-2">
+    @foreach (App\Enums\PakSlug::cases() as $pak)
+    <label class="leading-6 text-gray-900 pr-3 font-medium dark:text-white">
+        <input type="checkbox" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600" wire:model="paks.{{$pak->value}}" />
+        {{__('misc.'.$pak->value)}}</label>
+    @endforeach
+
+    @foreach (App\Enums\SiteName::cases() as $site)
+    <label class="leading-6 text-gray-900 pr-3 font-medium dark:text-white">
+        <input type="checkbox" class="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600" wire:model="sites.{{$site->value}}" />{{__('misc.'.$site->value)}}</label>
+    @endforeach
+</div>
+<div class="inline-flex rounded-md shadow-sm" role="group">
+    <input type="text" id="keyword" class="px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-s-lg hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:hover:text-white dark:hover:bg-gray-700" placeholder="キーワード" wire:model="keyword" wire:keydown.enter="onConditionUpdate" />
+    <button type="button" class="px-4 py-2 text-sm font-medium text-gray-900 bg-white border-t border-b border-gray-200 hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:hover:text-white dark:hover:bg-gray-700" wire:click="onConditionUpdate">検索</button>
+    <button type="button" class="px-4 py-2 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-e-lg hover:bg-gray-100 hover:text-blue-700 dark:bg-gray-800 dark:border-gray-700 dark:text-white dark:hover:text-white dark:hover:bg-gray-700" wire:click="clear">リセット</button>
+</div>
+@error('keyword')
+    <p class="text-xs text-red-600 dark:text-red-400">{{ $message }}</p>
+@enderror

--- a/resources/views/livewire/partials/pages-pagination.blade.php
+++ b/resources/views/livewire/partials/pages-pagination.blade.php
@@ -1,0 +1,3 @@
+<div class="my-4">
+    {{ $this->pages->onEachSide(1)->links('tailwind_custom') }}
+</div>

--- a/resources/views/livewire/partials/pages-results.blade.php
+++ b/resources/views/livewire/partials/pages-results.blade.php
@@ -1,0 +1,20 @@
+<ul>
+    @forelse ($this->pages as $page)
+    <li class="my-2">
+        <div>
+            @foreach ($page->paks as $pak)
+            <span class="inline-flex items-center rounded-md bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20">{{ __('misc.'.$pak->slug->value) }}</span>
+            @endforeach
+
+            <span class="inline-flex items-center rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10">{{ __('misc.'.$page->site_name->value) }}</span>
+
+            <a target="_blank" rel="noopener noreferrer" class="text-blue-600 dark:text-blue-500 hover:underline" href="{{ $page->url }}">{{ $page->title }}</a>
+
+            <span class="text-xs font-medium text-gray-600 dark:text-gray-300">{{ $page->last_modified->toDateTimeString() }}</span>
+        </div>
+        <div class="text-gray-900 text-sm px-5 py-2.5 dark:text-white">{{ $page->getSummary(300) }}</div>
+    </li>
+    @empty
+    <li class="my-2">該当なし</li>
+    @endforelse
+</ul>


### PR DESCRIPTION
## Summary
- `resources/views/livewire/pages.blade.php` に「フィルタUI」「検索結果一覧」「ページネーション」の3つの責務が同居しており、ページネーションリンクのマークアップも一覧の上下2箇所に丸ごと重複していた。
- `resources/views/livewire/partials/` 配下に `pages-filter.blade.php`（フィルタUI）・`pages-results.blade.php`（検索結果一覧）・`pages-pagination.blade.php`（ページネーションリンク、上下で`@include`し重複を解消）を切り出し、`pages.blade.php` はそれらを`@include`するだけの構成に整理した。
- Livewireのネストコンポーネント化・Islands化も検討した上で見送った：
  - ネストコンポーネント化: `LengthAwarePaginator`を安全にpropとして渡す組み込みSynthesizerが無く（Eloquent Model/Collectionにはあるが、Paginatorには無いことをvendorソースで確認済み）、シリアライズ周りのリスクが増える割に、このページの規模では恩恵が薄い。
  - Islands化: このページは検索条件を変えると結果自体が必ず変わる（`onConditionUpdate`が実行されると常に一覧も更新される）ため、再描画範囲を絞る効果がほぼ無く、目的に合わない。
  - 上記の理由で、`Pages.php`（PHPクラス側の状態管理・`#[Computed]`・バリデーション等）は一切変更せず、Bladeテンプレートの整理のみに留めた。

E:\chore\best_practice\livewire.md のアンチパターンチェックリスト(3)に基づく対応。

## Test plan
- [x] `./vendor/bin/pint --test`
- [x] `./vendor/bin/phpstan analyse`（level 9, 全体, エラーなし）
- [x] `./vendor/bin/rector process --dry-run`（変更対象ファイルに提案なし）
- [x] `php artisan test`（65件全て通過。`$this->pages`が`@include`パーシャル内でも問題なく解決されることを含め、既存のPagesTest 8件がそのまま通ることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
