### PR TITLE
fix: ページネーション遷移で検索キーワード等が引き継がれない不具合を修正

### DIFF
--- a/app/Livewire/Pages.php
+++ b/app/Livewire/Pages.php
@@ -20,6 +20,7 @@ use Livewire\Livewire;
 final class Pages extends Component
 {
     #[Validate('string|max:20')]
+    #[Url]
     public string $keyword = '';
 
     #[Url]
@@ -28,6 +29,7 @@ final class Pages extends Component
     /**
      * @var array<string|int,bool>
      */
+    #[Url]
     public array $paks = [
         PakSlug::Pak64->value => true,
         PakSlug::Pak128->value => true,
@@ -37,6 +39,7 @@ final class Pages extends Component
     /**
      * @var array<string,bool>
      */
+    #[Url]
     public array $sites = [
         SiteName::Japan->value => true,
         SiteName::Twitrans->value => true,
@@ -64,11 +67,6 @@ final class Pages extends Component
      * ページネーションリンクは通常のURL遷移（`?page=N`）で行われ、`#[Url] $page` が
      * 「今何ページ目か」を表す唯一の状態源。検索条件（キーワード・pak・サイト）を
      * 変えたときは、ここで明示的に1ページ目へ戻す。
-     *
-     * 注意: `$keyword`/`$paks`/`$sites`は`#[Url]`化していないため、ページネーション
-     * リンク（プレーンな`<a href>`によるページ遷移）をクリックすると検索条件はURLに
-     * 乗らず、デフォルト状態でコンポーネントが再マウントされる（既知の制限。今回の
-     * 修正はページ番号の二重管理を解消する範囲に限定しており、この制限自体はスコープ外）。
      */
     public function onConditionUpdate(): void
     {
@@ -86,13 +84,24 @@ final class Pages extends Component
     #[Computed]
     public function pages(): LengthAwarePaginator
     {
-        return (new SearchAction)([
+        $pages = (new SearchAction)([
             'keyword' => $this->keyword,
             'paks' => $this->selectedPaks(),
             'sites' => $this->selectedSites(),
             // #[Url]は型不一致(TypeError)は弾くが、0以下の値はintとして許してしまうため、
             // ?page=-1 のような不正なURLでもここで1に丸める。
             'page' => max(1, $this->page),
+        ]);
+
+        // ページネーションリンク（プレーンな<a href>によるURL遷移）に検索条件を
+        // 引き継がせる。request()->query()に頼るwithQueryString()はLivewireの
+        // AJAXリクエスト中は正しく機能しない（アドレスバーではなくAJAX
+        // エンドポイント自体のクエリ文字列を見てしまう）ため、コンポーネントの
+        // プロパティから明示的に構築する。
+        return $pages->appends([
+            'keyword' => $this->keyword,
+            'paks' => $this->paks,
+            'sites' => $this->sites,
         ]);
     }
 

--- a/tests/Feature/Livewire/PagesTest.php
+++ b/tests/Feature/Livewire/PagesTest.php
@@ -66,8 +66,35 @@ final class PagesTest extends TestCase
             ->call('onConditionUpdate')
             ->html();
 
-        $this->assertMatchesRegularExpression('#href="[^"]*\?page=2"#', $html);
-        $this->assertStringNotContainsString('/update?page=2', $html);
+        $this->assertMatchesRegularExpression('#href="[^"]*[?&](amp;)?page=2[^"]*"#', $html);
+        $this->assertStringNotContainsString('/update?', $html);
+        $this->assertStringNotContainsString('/update&amp;', $html);
+    }
+
+    public function test_pagination_links_preserve_search_conditions_across_pages(): void
+    {
+        // 検索キーワード等がページネーションリンク（プレーンな<a href>によるURL遷移）に
+        // 引き継がれず、2ページ目に遷移すると検索条件が失われる不具合の回帰テスト。
+        $pak = Pak::factory()->create(['slug' => PakSlug::Pak128]);
+        for ($i = 0; $i < 60; $i++) {
+            $page = Page::factory()->create([
+                'site_name' => SiteName::Japan,
+                'title' => "Locomotive Addon {$i}",
+                'url' => "https://example.test/loco-{$i}",
+                'raw_page_id' => RawPage::factory()->create(['url' => "https://example.test/loco-raw-{$i}"])->id,
+            ]);
+            $page->paks()->attach($pak);
+        }
+
+        $html = Livewire::test(Pages::class)
+            ->set('keyword', 'Locomotive')
+            ->set('paks.'.PakSlug::Pak64->value, false)
+            ->call('onConditionUpdate')
+            ->html();
+
+        $this->assertMatchesRegularExpression('#href="[^"]*[?&](amp;)?page=2[^"]*"#', $html);
+        $this->assertMatchesRegularExpression('#href="[^"]*keyword=Locomotive[^"]*"#', $html);
+        $this->assertMatchesRegularExpression('#href="[^"]*paks%5B'.PakSlug::Pak64->value.'%5D=0[^"]*"#', $html);
     }
 
     public function test_clear_resets_keyword_paks_sites_and_page(): void


### PR DESCRIPTION
## Summary

`$keyword`/`$paks`/`$sites` が `#[Url]` 化されておらず、ページネーションリンク（プレーンな `<a href>` によるURL遷移）にも検索条件が乗っていなかったため、2ページ目以降に遷移すると検索条件がリセットされた状態でコンポーネントが再マウントされていました（[#187](https://github.com/128na/SimutransCrossSearch/pull/187)/[#188](https://github.com/128na/SimutransCrossSearch/pull/188)のセルフレビューで発見していた既知の制限です）。

- `$keyword`/`$paks`/`$sites` に `#[Url]` を追加し、フルページ遷移後もURLから状態を復元できるようにしました。
- `pages()` が返すpaginatorに `->appends([...])` で現在の検索条件を明示的に付与し、生成されるページネーションリンクに検索条件が引き継がれるようにしました。`withQueryString()` はLivewireのAJAXリクエスト中は `request()->query()`（アドレスバーではなくAJAXエンドポイント自体のクエリ文字列）を参照してしまい正しく機能しないため、コンポーネントのプロパティから直接構築する方式にしています。
- 回帰テストを追加（ページネーションリンクに `keyword`/`paks` が実際に含まれることを確認）。

なお既存テストの正規表現がクエリパラメータの並び順・エスケープ形式（`&`ではなくBladeでエスケープされた`&amp;`）に依存していたため、より頑健な形に修正しています。

## Test plan
- [x] `./vendor/bin/pint --test`
- [x] `./vendor/bin/phpstan analyse`（全体、エラーなし）
- [x] `./vendor/bin/rector process --dry-run`（提案なし）
- [x] `php artisan test`（66件全て通過。新規回帰テストで、2ページ目リンクに `keyword=Locomotive` と `paks%5B64%5D=0` が実際に含まれることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
