### PR TITLE
fix: pak/siteチェックボックスがURL遷移後に実際の選択状態を反映しない不具合を修正

### DIFF
--- a/app/Livewire/Pages.php
+++ b/app/Livewire/Pages.php
@@ -56,6 +56,15 @@ final class Pages extends Component
     public function boot(): void
     {
         Paginator::currentPathResolver(fn (): string => Livewire::originalPath());
+
+        // #[Url]経由でURLクエリ文字列から配列をハイドレートすると、値が
+        // 真偽値ではなく文字列 '0'/'1' になる（PHP側のarray_filter等では
+        // '0'はfalsy値として扱われるため検索フィルタ自体は正しく動作するが、
+        // フロントに送られるJSON上は非空文字列としてtruthyに評価されてしまい、
+        // チェックボックスの表示が実際の選択状態を反映しなくなる）。
+        // 明示的にboolへキャストし直して補正する。
+        $this->paks = array_map(fn (mixed $value): bool => (bool) $value, $this->paks);
+        $this->sites = array_map(fn (mixed $value): bool => (bool) $value, $this->sites);
     }
 
     public function render(): View

--- a/tests/Feature/Livewire/PagesTest.php
+++ b/tests/Feature/Livewire/PagesTest.php
@@ -97,6 +97,32 @@ final class PagesTest extends TestCase
         $this->assertMatchesRegularExpression('#href="[^"]*paks%5B'.PakSlug::Pak64->value.'%5D=0[^"]*"#', $html);
     }
 
+    public function test_paks_and_sites_are_normalized_to_booleans_after_url_hydration(): void
+    {
+        // #[Url]によるクエリ文字列からの配列ハイドレートは値が真偽値ではなく
+        // 文字列'0'/'1'になる。PHP側のarray_filter等では'0'はfalsy値として
+        // 扱われ検索フィルタは正しく動作するが、フロントに送られるJSON上は
+        // 非空文字列としてtruthyに評価され、チェックボックスの表示が実際の
+        // 選択状態を反映しなくなる不具合の回帰テスト。assertSetはゆるい比較
+        // ('0' == false は true)のため検知できず、instance()の値を厳密に
+        // 比較する。
+        $testable = Livewire::withQueryParams([
+            'paks' => ['64' => '0', '128' => '1', '128-japan' => '1'],
+            'sites' => ['japan' => '1', 'twitrans' => '0', 'portal' => '1'],
+        ])->test(Pages::class);
+
+        $this->assertSame([
+            PakSlug::Pak64->value => false,
+            PakSlug::Pak128->value => true,
+            PakSlug::Pak128Jp->value => true,
+        ], $testable->instance()->paks);
+        $this->assertSame([
+            SiteName::Japan->value => true,
+            SiteName::Twitrans->value => false,
+            SiteName::Portal->value => true,
+        ], $testable->instance()->sites);
+    }
+
     public function test_clear_resets_keyword_paks_sites_and_page(): void
     {
         Livewire::test(Pages::class)


### PR DESCRIPTION
## Summary

[#189](https://github.com/128na/SimutransCrossSearch/pull/189) で `$paks`/`$sites` を `#[Url]` 化した際に生じた回帰です。URLクエリ文字列からの配列ハイドレート（`Livewire\Features\SupportQueryString\BaseUrl`）が値を真偽値ではなく文字列 `'0'`/`'1'` に変換してしまいます。

PHP側の `array_filter()`（`selectedPaks()`/`selectedSites()` で使用）は文字列 `'0'` をfalsy値として扱うため検索フィルタ自体は正しく動作していましたが、フロントエンドに送られる `wire:snapshot` のJSON上では非空文字列としてtruthyに評価され、チェックボックスの表示（Livewireのクライアント側JSがJSON値の真偽判定で `checked` 状態を決めている）が実際の選択状態を反映しなくなっていました。

`boot()` で `$paks`/`$sites` を明示的にbool配列へキャストし直すことで補正しました。

`Livewire::withQueryParams()` でクエリ文字列付きマウントを再現し、修正前は実際に失敗する回帰テストを追加しています。`assertSet` はゆるい比較（`'0' == false` は `true`）のため検知できず、`instance()` の値を `assertSame` で厳密比較する必要がありました（実際に修正を一時的に無効化して失敗することを確認済み）。

## Test plan
- [x] `./vendor/bin/pint --test`
- [x] `./vendor/bin/phpstan analyse`（全体、エラーなし）
- [x] `./vendor/bin/rector process --dry-run`（提案を適用済み）
- [x] `php artisan test`（67件全て通過）
- [x] 修正を一時的に無効化して新規テストが実際に失敗することを確認済み
- [x] `wire:snapshot` のJSONを直接確認し、修正後は `"paks":{"64":false,"128":true,...}` のように真偽値として正しくシリアライズされることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
